### PR TITLE
Settings/qa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,78 +1,45 @@
-name: Prüfung & CI
-
 on:
   pull_request:
-    branches: [main] # PRs erzeugen QA-Previews
+    branches: [main]
   push:
-    branches: [main] # Merge nach main = Produktion
+    branches: [main]
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
+        with: { node-version: 20, cache: npm }
+      - run: npm ci
+      - run: npx prettier --check .
+      - run: npm run type-check
+      - run: npm run test
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: dist }
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Prettier Check
-        run: npx prettier --check .
-
-      - name: Type Check
-        run: npm run type-check
-
-      - name: Tests
-        run: npm run test
-
-      - name: Build
-        run: npm run build
-
-      # wichtig: Artefakt für Deploy-Jobs bereitstellen
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  # QA-Preview bei PRs
   deploy_preview:
     if: github.event_name == 'pull_request'
     needs: checks
     runs-on: ubuntu-latest
-    environment:
-      name: preview
-      url: ${{ steps.deployment.outputs.page_url }}
+    environment: { name: preview, url: ${{ steps.deployment.outputs.page_url }} }
     steps:
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-      - name: Deploy Preview
-        id: deployment
+      - uses: actions/configure-pages@v5
+      - id: deployment
         uses: actions/deploy-pages@v4
 
-  # Produktion bei Push auf main
   deploy_prod:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: checks
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: ${{ steps.deployment.outputs.page_url }}
+    environment: { name: production, url: ${{ steps.deployment.outputs.page_url }} }
     steps:
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - uses: actions/configure-pages@v5
+      - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Ich habe diesen Branch so angepasst, dass er beim Erstellen des Pull Requests automatisch als Preview-Version auf GitHub Pages deployed wird. Dadurch kann ich schon vor dem Merge testen, ob alles zusammen funktioniert.

Die Abläufe sind jetzt so:
- Sobald ich den PR öffne oder neue Commits pushe, wird eine frische Preview-Seite gebaut und online gestellt.
- Über die bereitgestellte URL kann ich und können Reviewer die Anwendung so ausprobieren, wie sie später produktiv laufen würde.
- Wenn ich den PR merge, wird derselbe Build-Prozess auf main ausgeführt und die Seite geht automatisch produktiv live.