### PR TITLE
UI adoption an die Algos + weitere Anpassungen am chart

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,44 +2,42 @@
   <div class="shell">
     <header class="bar">
       <div class="bar-inner">
-        <!-- kleine Brand-Ecke. Wow, so minimalistisch. -->
         <div class="brand">Bandit Lab</div>
       </div>
     </header>
 
     <main class="wrap">
       <div class="page-grid">
-        <!--  LINKS: Setup, Modus & Interaktion (manuell/worker) -->
+        <!-- Linke Spalte: Environment + Interaktion -->
         <div class="col-left">
-          <!--  hier wird das Environment zurechtgebastelt -->
           <EnvSetup
-            v-model="form"
-            :busy="busy"
-            @inited="onInited"
-            @log="setLast"
+              v-model="form"
+              :busy="busy"
+              @inited="onInited"
+              @log="setLast"
           >
-            <!-- Modus-Schalter: „Manuell“ oooder „Algorithmus“    -->
             <template #actions>
               <ModeSwitch v-model="mode" @change="onModeChange" />
             </template>
           </EnvSetup>
 
-          <!-- jeder Klick = 1 Zuschauer -->
+          <!-- Manuell: Klick = Zuschauer; Algorithmen steppen mit -->
           <section class="card" v-if="mode === 'manual'">
             <h2>Manuell testen</h2>
-            <p class="muted">Ein Klick entspricht genau einem Zuschauer.</p>
+            <p class="muted">
+              Jeder Klick triggert zusätzlich alle Algorithmen für einen Schritt.
+            </p>
 
-            <!-- Thumbnails -->
             <div class="thumb-grid">
               <ThumbnailCard
-                v-for="i in form.arms"
-                :key="i"
-                :label="`Thumbnail ${String.fromCharCode(64 + i)}`"
-                :variant="`Variante ${String.fromCharCode(64 + i)}`"
-                :n="snapshot?.counts[i - 1] || 0"
-                :estimate="estimateText(i - 1)"
-                :truth="truthText(i - 1)"
-                @pick="onManual(i - 1)"
+                  v-for="i in form.arms"
+                  :key="i"
+                  :label="`Thumbnail ${String.fromCharCode(64 + i)}`"
+                  :variant="`Variante ${String.fromCharCode(64 + i)}`"
+                  :n="snapshot?.counts[i - 1] || 0"
+                  :estimate="estimateText(i - 1)"
+                  :truth="truthText(i - 1)"
+                  @pick="onManual(i - 1)"
               />
             </div>
 
@@ -49,38 +47,32 @@
             </div>
           </section>
 
-          <!-- Falls der Modus „Algorithmus“ ist: Worker-Steuerung (Start/Pause etc.) -->
+          <!-- Algorithmus-Modus -->
           <RunnerControls
-            v-else
-            :envId="envId || null"
-            :arms="snapshot?.config?.arms || form.arms"
+              v-else
+              :envId="envId || null"
+              :arms="snapshot?.config?.arms || form.arms"
           />
         </div>
 
-        <!-- RECHTS: Chart oben, Debug & Tabelle unten -->
+        <!-- Rechte Spalte: Chart + Debug + Tabelle -->
         <div class="col-right">
           <section class="card">
             <h2>Verläufe</h2>
-            <!-- Chart bekommt:
-                 - series: die Daten (z.B. manuell, später algos)
-                 - v-model: aktive Kennzahl (Σ, Ø, Regret, ...)
-                 - @toggle: Sichtbarkeit einzelner Serien (Pillen oben) -->
             <ChartArea
-              :series="chartSeries"
-              v-model="chartMetric"
-              @toggle="onChartToggle"
+                :series="chartSeries"
+                v-model="chartMetric"
+                @toggle="onChartToggle"
             />
           </section>
 
-          <!-- Debug-Panel: kommt später weg. -->
           <DebugPanel :snapshot="snapshot" :lastResult="lastResult" />
 
-          <!-- Vergleichstabelle  -->
           <ComparisonTable
-            class="card"
-            :rows="metricRows"
-            v-model:open="tableOpen"
-            @toggleSeries="onToggleSeries"
+              class="card"
+              :rows="metricRows"
+              v-model:open="tableOpen"
+              @toggleSeries="onToggleSeries"
           />
         </div>
       </div>
@@ -89,17 +81,11 @@
 </template>
 
 <script setup lang="ts">
-/**
- * Hier läuft alles zusammen: Setup links, Chart/Debug/Tabelle rechts.
- */
+import { computed, ref, onBeforeUnmount } from "vue";
 
-import { computed, ref } from "vue";
-
-// --- Domain: Env/Client
 import type { iEnvConfig } from "./env/Domain/iEnvConfig";
 import { getEnvSnapshot, pullAction } from "./api/banditClient";
 
-// --- UI-Komponenten
 import EnvSetup from "./components/EnvSetup.vue";
 import DebugPanel from "./components/DebugPanel.vue";
 import ThumbnailCard from "./components/ThumbnailCard.vue";
@@ -108,7 +94,6 @@ import ModeSwitch from "./components/ModeSwitch.vue";
 import ChartArea from "./components/ChartArea.vue";
 import ComparisonTable from "./components/ComparisonTable.vue";
 
-// --- Datenformen & Services
 import type { ManualStep } from "./domain/iHistory";
 import type { iMetricsRow } from "./domain/iMetrics";
 import type { iChartSeries } from "./domain/chart/iChartSeries";
@@ -124,7 +109,8 @@ import {
   buildSeriesFromManual,
 } from "./services/metrics";
 
-// Minimaler Snapshot-Typ, der für Debug/Texte reicht
+import { algorithmsRunner } from "./services/algorithmsRunner";
+
 type EnvSnapshot = {
   config: iEnvConfig;
   optimalAction: number;
@@ -132,7 +118,12 @@ type EnvSnapshot = {
   estimates: number[];
 };
 
-// --- State
+const algoCatalog = [
+  { id: "greedy", label: "Greedy", color: "#4fc3f7" },
+  { id: "epsgreedy", label: "ε-Greedy", color: "#f39c12" },
+] as const;
+type AlgoId = (typeof algoCatalog)[number]["id"];
+
 const form = ref<iEnvConfig>({ type: "gaussian", arms: 6, seed: 12345 });
 const envId = ref("");
 const busy = ref(false);
@@ -141,38 +132,40 @@ const snapshot = ref<EnvSnapshot | null>(null);
 const lastResult = ref("");
 const lastEventText = ref("—");
 
-// Modus: „manual“ oder „algo“
 const mode = ref<"manual" | "algo">("manual");
-
-// Tabelle fold/unfold
 const tableOpen = ref(false);
-
-// Chart: Welche Kennzahl gucken wir uns gerade an?
 const chartMetric = ref<ChartMetric>("cumReward");
 
-// Historie der Handklicks
 const manualHistory = ref<ManualStep[]>([]);
-
-// Sichtbarkeiten & Farben der Serien
 const seriesState = getSeriesState();
 
-/* ── Helferlein (klein & nützlich) ───────────────────────────────────────── */
+const algoHistory = ref<Record<string, ManualStep[]>>(
+    Object.fromEntries(algoCatalog.map((a) => [a.id, []])),
+);
 
-function setLast(msg: string) {
-  lastResult.value = msg; // einfach wegschreiben und gut
+// rAF-Drosselung für Re-Renders
+const algoRev = ref(0);
+let rafPending = false;
+function scheduleRender() {
+  if (rafPending) return;
+  rafPending = true;
+  requestAnimationFrame(() => {
+    rafPending = false;
+    algoRev.value++;
+  });
 }
 
+/* Helpers */
+function setLast(msg: string) {
+  lastResult.value = msg;
+}
 function onModeChange(v: "manual" | "algo") {
   setLast(`Modus gewechselt: ${v === "manual" ? "Manuell" : "Algorithmus"}`);
 }
-
-// Snapshot nachladen (wenn ein Env existiert)
 function refresh() {
   if (!envId.value) return;
   snapshot.value = getEnvSnapshot(envId.value);
 }
-
-// Texte für die Thumbnails
 function estimateText(idx: number) {
   const q = snapshot.value?.estimates[idx] ?? 0;
   return `${q.toFixed(0)}s`;
@@ -180,43 +173,70 @@ function estimateText(idx: number) {
 function truthText(idx: number) {
   const cfg = snapshot.value?.config;
   if (!cfg) return "—";
-  const mu = cfg.means?.[idx];
-  const sd = cfg.stdDev?.[idx];
-  return mu != null && sd != null
-    ? `${mu.toFixed(0)}s ± ${sd.toFixed(0)}s`
-    : "—";
+  const mu = (cfg as any).means?.[idx];
+  const sd = (cfg as any).stdDev?.[idx];
+  return mu != null && sd != null ? `${mu.toFixed(0)}s ± ${sd.toFixed(0)}s` : "—";
 }
 
-// Neues Env initialisiert? -> Alles frisch machen.
+/* Serien dauerhaft registrieren (Pillen) */
+ensureSeries("manual", "Manuell", "#4caf50");
+for (const a of algoCatalog) ensureSeries(a.id, a.label, a.color);
+
+/* Runner-Konfiguration für aktuelles Env */
+function configureAlgoRunnerForCurrentEnv() {
+  if (!envId.value) return;
+  const snap = getEnvSnapshot(envId.value);
+  if (!snap?.config) return;
+
+  algorithmsRunner.configure({
+    envConfig: snap.config,
+    totalSteps: 0, // open-ended: nur stepOnce() on demand
+    rate: 1,
+  });
+}
+
+/* Env initialisiert */
 function onInited({ envId: id }: { envId: string; optimalAction: number }) {
   envId.value = id;
-  manualHistory.value = []; // zurück auf Anfang (Reset tut gut)
-  resetSeriesStore(); // Sichtbarkeiten/Farben resseten (ja, mit 2 s, kann pasieren)
-  ensureSeries("manual", "Manuell", "#4caf50"); // grün = manuell, easy zu merken
+
+  manualHistory.value = [];
+
+  resetSeriesStore();
+  ensureSeries("manual", "Manuell", "#4caf50");
+  for (const a of algoCatalog) ensureSeries(a.id, a.label, a.color);
+
+  for (const a of algoCatalog) algoHistory.value[a.id] = [];
+  scheduleRender();
+
   refresh();
+  configureAlgoRunnerForCurrentEnv();
 }
 
-// Ein manueller Klick (=> 1 Zuschauer) – wir ziehen am Env und loggen das Ergebnis
+/* Manuelle Interaktion: zusätzlich alle Algorithmen steppen */
 async function onManual(a: number) {
   if (!envId.value) return;
+
+  if (algorithmsRunner.getStatus() === "IDLE") {
+    configureAlgoRunnerForCurrentEnv();
+  }
+
   busy.value = true;
   try {
     const res = await pullAction(envId.value, a);
-
-    // ab in die Historie
     manualHistory.value.push({
       action: res.action,
       reward: res.reward,
       isOptimal: res.isOptimal,
     });
 
-    // bisschen Feedback fürs testen später
     setLast(JSON.stringify({ manual: true, ...res }, null, 2));
     lastEventText.value = `Thumbnail ${String.fromCharCode(65 + a)} → Watchtime ${res.reward.toFixed(
-      0,
+        0,
     )}s · optimal: ${res.isOptimal ? "ja" : "nein"}`;
 
+    algorithmsRunner.stepOnce(); // ein Schritt für alle Policies
     refresh();
+    scheduleRender();
   } catch (e: any) {
     setLast(`Fehler: ${e?.message ?? e}`);
     console.error(e);
@@ -225,46 +245,73 @@ async function onManual(a: number) {
   }
 }
 
-/* ── Abgeleitete Daten (Tabelle & Chart) ─────────────────────────────────── */
+/* Runner-Events → Algorithmen-Historie */
+const offRunner = algorithmsRunner.on((e) => {
+  switch (e.type) {
+    case "CONFIGURED": {
+      for (const m of algorithmsRunner.getAll()) {
+        ensureSeries(m.id, m.label, m.color);
+        if (!algoHistory.value[m.id]) algoHistory.value[m.id] = [];
+      }
+      scheduleRender();
+      break;
+    }
+    case "RESULT": {
+      const id = e.payload.policyId as AlgoId;
+      const arr = algoHistory.value[id] ?? (algoHistory.value[id] = []);
+      arr.push({
+        action: e.payload.action,
+        reward: e.payload.reward,
+        isOptimal: e.payload.isOptimal,
+      });
+      scheduleRender();
+      break;
+    }
+    default:
+      break;
+  }
+});
 
-// 1) Tabelle: aktuell nur „Manuell“ (Algos kommen dazu, dann werden es mehrere Rows)
+onBeforeUnmount(() => {
+  offRunner();
+});
+
+/* Tabelle */
 const metricRows = computed<iMetricsRow[]>(() => {
-  const s = seriesState.manual; // Sichtbarkeit/Farbe aus dem Store
-  return [
-    buildMetricsRowFromManual(manualHistory.value, snapshot.value?.config, s),
-  ];
+  void algoRev.value; // rAF-getaktet
+  const rows: iMetricsRow[] = [];
+
+  rows.push(buildMetricsRowFromManual(manualHistory.value, snapshot.value?.config, seriesState.manual));
+  for (const a of algoCatalog) {
+    const s = (seriesState as any)[a.id];
+    rows.push(buildMetricsRowFromManual(algoHistory.value[a.id] ?? [], snapshot.value?.config, s));
+  }
+  return rows;
 });
 
-// 2) Chart-Serien: dito – aktuell nur „Manuell“
+/* Chart */
 const chartSeries = computed<iChartSeries[]>(() => {
-  const s = seriesState.manual;
-  const serie = buildSeriesFromManual(
-    manualHistory.value,
-    snapshot.value?.config,
-    s,
-  );
-  return [serie];
+  void algoRev.value; // rAF-getaktet
+  const out: iChartSeries[] = [];
+
+  out.push(buildSeriesFromManual(manualHistory.value, snapshot.value?.config, seriesState.manual));
+  for (const a of algoCatalog) {
+    const s = (seriesState as any)[a.id];
+    out.push(buildSeriesFromManual(algoHistory.value[a.id] ?? [], snapshot.value?.config, s));
+  }
+  return out;
 });
 
-// Tabelle toggelt Sichtbarkeit -> Store aktualisieren
-function onToggleSeries({
-  seriesId,
-  visible,
-}: {
-  seriesId: string;
-  visible: boolean;
-}) {
+/* Sichtbarkeiten syncen */
+function onToggleSeries({ seriesId, visible }: { seriesId: string; visible: boolean }) {
   setSeriesVisible(seriesId, visible);
 }
-
-// Chart toggelt Sichtbarkeit -> gleiche Funktion (Single Source of Truth, baby)
 function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
   setSeriesVisible(id, visible);
 }
 </script>
 
 <style scoped>
-/*  wir wollen volle Breite. */
 .wrap {
   max-width: none;
   width: 100%;
@@ -272,7 +319,6 @@ function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
   box-sizing: border-box;
 }
 
-/* Kopfzele */
 .bar-inner {
   display: flex;
   align-items: center;
@@ -283,7 +329,6 @@ function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
   box-sizing: border-box;
 }
 
-/* Zwei-Spalten */
 .page-grid {
   display: grid;
   gap: 16px;
@@ -294,14 +339,12 @@ function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
   position: relative;
 }
 
-/* Thumbnails: drei pro Reihe. */
 .thumb-grid {
   display: grid;
   gap: 18px;
   grid-template-columns: repeat(3, 1fr);
 }
 
-/* kleines Toast-Element  */
 .toast {
   display: flex;
   align-items: center;
@@ -320,20 +363,13 @@ function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
   font-size: 12px;
 }
 
-/* für mobile und kleinere displays */
 @media (max-width: 1200px) {
-  .page-grid {
-    grid-template-columns: 1fr;
-  }
+  .page-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 980px) {
-  .thumb-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  .thumb-grid { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 620px) {
-  .thumb-grid {
-    grid-template-columns: 1fr;
-  }
+  .thumb-grid { grid-template-columns: 1fr; }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,10 @@
         <!-- Linke Spalte: Environment + Interaktion -->
         <div class="col-left">
           <EnvSetup
-              v-model="form"
-              :busy="busy"
-              @inited="onInited"
-              @log="setLast"
+            v-model="form"
+            :busy="busy"
+            @inited="onInited"
+            @log="setLast"
           >
             <template #actions>
               <ModeSwitch v-model="mode" @change="onModeChange" />
@@ -25,19 +25,20 @@
           <section class="card" v-if="mode === 'manual'">
             <h2>Manuell testen</h2>
             <p class="muted">
-              Jeder Klick triggert zusätzlich alle Algorithmen für einen Schritt.
+              Jeder Klick triggert zusätzlich alle Algorithmen für einen
+              Schritt.
             </p>
 
             <div class="thumb-grid">
               <ThumbnailCard
-                  v-for="i in form.arms"
-                  :key="i"
-                  :label="`Thumbnail ${String.fromCharCode(64 + i)}`"
-                  :variant="`Variante ${String.fromCharCode(64 + i)}`"
-                  :n="snapshot?.counts[i - 1] || 0"
-                  :estimate="estimateText(i - 1)"
-                  :truth="truthText(i - 1)"
-                  @pick="onManual(i - 1)"
+                v-for="i in form.arms"
+                :key="i"
+                :label="`Thumbnail ${String.fromCharCode(64 + i)}`"
+                :variant="`Variante ${String.fromCharCode(64 + i)}`"
+                :n="snapshot?.counts[i - 1] || 0"
+                :estimate="estimateText(i - 1)"
+                :truth="truthText(i - 1)"
+                @pick="onManual(i - 1)"
               />
             </div>
 
@@ -49,9 +50,9 @@
 
           <!-- Algorithmus-Modus -->
           <RunnerControls
-              v-else
-              :envId="envId || null"
-              :arms="snapshot?.config?.arms || form.arms"
+            v-else
+            :envId="envId || null"
+            :arms="snapshot?.config?.arms || form.arms"
           />
         </div>
 
@@ -60,19 +61,19 @@
           <section class="card">
             <h2>Verläufe</h2>
             <ChartArea
-                :series="chartSeries"
-                v-model="chartMetric"
-                @toggle="onChartToggle"
+              :series="chartSeries"
+              v-model="chartMetric"
+              @toggle="onChartToggle"
             />
           </section>
 
           <DebugPanel :snapshot="snapshot" :lastResult="lastResult" />
 
           <ComparisonTable
-              class="card"
-              :rows="metricRows"
-              v-model:open="tableOpen"
-              @toggleSeries="onToggleSeries"
+            class="card"
+            :rows="metricRows"
+            v-model:open="tableOpen"
+            @toggleSeries="onToggleSeries"
           />
         </div>
       </div>
@@ -140,7 +141,7 @@ const manualHistory = ref<ManualStep[]>([]);
 const seriesState = getSeriesState();
 
 const algoHistory = ref<Record<string, ManualStep[]>>(
-    Object.fromEntries(algoCatalog.map((a) => [a.id, []])),
+  Object.fromEntries(algoCatalog.map((a) => [a.id, []])),
 );
 
 // rAF-Drosselung für Re-Renders
@@ -175,7 +176,9 @@ function truthText(idx: number) {
   if (!cfg) return "—";
   const mu = (cfg as any).means?.[idx];
   const sd = (cfg as any).stdDev?.[idx];
-  return mu != null && sd != null ? `${mu.toFixed(0)}s ± ${sd.toFixed(0)}s` : "—";
+  return mu != null && sd != null
+    ? `${mu.toFixed(0)}s ± ${sd.toFixed(0)}s`
+    : "—";
 }
 
 /* Serien dauerhaft registrieren (Pillen) */
@@ -231,7 +234,7 @@ async function onManual(a: number) {
 
     setLast(JSON.stringify({ manual: true, ...res }, null, 2));
     lastEventText.value = `Thumbnail ${String.fromCharCode(65 + a)} → Watchtime ${res.reward.toFixed(
-        0,
+      0,
     )}s · optimal: ${res.isOptimal ? "ja" : "nein"}`;
 
     algorithmsRunner.stepOnce(); // ein Schritt für alle Policies
@@ -281,10 +284,22 @@ const metricRows = computed<iMetricsRow[]>(() => {
   void algoRev.value; // rAF-getaktet
   const rows: iMetricsRow[] = [];
 
-  rows.push(buildMetricsRowFromManual(manualHistory.value, snapshot.value?.config, seriesState.manual));
+  rows.push(
+    buildMetricsRowFromManual(
+      manualHistory.value,
+      snapshot.value?.config,
+      seriesState.manual,
+    ),
+  );
   for (const a of algoCatalog) {
     const s = (seriesState as any)[a.id];
-    rows.push(buildMetricsRowFromManual(algoHistory.value[a.id] ?? [], snapshot.value?.config, s));
+    rows.push(
+      buildMetricsRowFromManual(
+        algoHistory.value[a.id] ?? [],
+        snapshot.value?.config,
+        s,
+      ),
+    );
   }
   return rows;
 });
@@ -294,16 +309,34 @@ const chartSeries = computed<iChartSeries[]>(() => {
   void algoRev.value; // rAF-getaktet
   const out: iChartSeries[] = [];
 
-  out.push(buildSeriesFromManual(manualHistory.value, snapshot.value?.config, seriesState.manual));
+  out.push(
+    buildSeriesFromManual(
+      manualHistory.value,
+      snapshot.value?.config,
+      seriesState.manual,
+    ),
+  );
   for (const a of algoCatalog) {
     const s = (seriesState as any)[a.id];
-    out.push(buildSeriesFromManual(algoHistory.value[a.id] ?? [], snapshot.value?.config, s));
+    out.push(
+      buildSeriesFromManual(
+        algoHistory.value[a.id] ?? [],
+        snapshot.value?.config,
+        s,
+      ),
+    );
   }
   return out;
 });
 
 /* Sichtbarkeiten syncen */
-function onToggleSeries({ seriesId, visible }: { seriesId: string; visible: boolean }) {
+function onToggleSeries({
+  seriesId,
+  visible,
+}: {
+  seriesId: string;
+  visible: boolean;
+}) {
   setSeriesVisible(seriesId, visible);
 }
 function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
@@ -364,12 +397,18 @@ function onChartToggle({ id, visible }: { id: string; visible: boolean }) {
 }
 
 @media (max-width: 1200px) {
-  .page-grid { grid-template-columns: 1fr; }
+  .page-grid {
+    grid-template-columns: 1fr;
+  }
 }
 @media (max-width: 980px) {
-  .thumb-grid { grid-template-columns: repeat(2, 1fr); }
+  .thumb-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 @media (max-width: 620px) {
-  .thumb-grid { grid-template-columns: 1fr; }
+  .thumb-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/src/components/ChartArea.vue
+++ b/src/components/ChartArea.vue
@@ -5,14 +5,14 @@
       <span class="label">Kennzahl</span>
       <div class="metric-pills" role="radiogroup" aria-label="Kennzahl wählen">
         <button
-            v-for="m in metrics"
-            :key="m.key"
-            class="pill metric"
-            :class="{ active: localMetric === m.key }"
-            role="radio"
-            :aria-checked="localMetric === m.key"
-            type="button"
-            @click="localMetric = m.key"
+          v-for="m in metrics"
+          :key="m.key"
+          class="pill metric"
+          :class="{ active: localMetric === m.key }"
+          role="radio"
+          :aria-checked="localMetric === m.key"
+          type="button"
+          @click="localMetric = m.key"
         >
           {{ m.label }}
         </button>
@@ -22,14 +22,18 @@
     <!-- Serien-Pillen -->
     <div class="series-toolbar" aria-label="Serien wählen">
       <button
-          v-for="s in series"
-          :key="s.config.id"
-          type="button"
-          class="pill series"
-          :class="{ off: !s.config.visible }"
-          :aria-pressed="s.config.visible"
-          :title="s.config.visible ? `${s.config.label} ausblenden` : `${s.config.label} einblenden`"
-          @click="onToggleSeries(s)"
+        v-for="s in series"
+        :key="s.config.id"
+        type="button"
+        class="pill series"
+        :class="{ off: !s.config.visible }"
+        :aria-pressed="s.config.visible"
+        :title="
+          s.config.visible
+            ? `${s.config.label} ausblenden`
+            : `${s.config.label} einblenden`
+        "
+        @click="onToggleSeries(s)"
       >
         <span class="dot" :style="{ background: s.config.color }" />
         <span class="name">{{ s.config.label }}</span>
@@ -37,12 +41,12 @@
     </div>
 
     <v-chart
-        ref="chartRef"
-        class="echart"
-        :option="option"
-        :update-options="updateOpts"
-        :autoresize="true"
-        @legendselectchanged="onLegendSelect"
+      ref="chartRef"
+      class="echart"
+      :option="option"
+      :update-options="updateOpts"
+      :autoresize="true"
+      @legendselectchanged="onLegendSelect"
     />
   </div>
 </template>
@@ -76,7 +80,10 @@ use([
 
 const chartRef = ref<InstanceType<typeof VChart> | null>(null);
 
-const props = defineProps<{ series: iChartSeries[]; modelValue?: ChartMetric }>();
+const props = defineProps<{
+  series: iChartSeries[];
+  modelValue?: ChartMetric;
+}>();
 const emit = defineEmits<{
   (e: "update:modelValue", v: ChartMetric): void;
   (e: "toggle", payload: { id: string; visible: boolean }): void;
@@ -90,25 +97,35 @@ const metrics: { key: ChartMetric; label: string }[] = [
   { key: "bestRate", label: "Best-Quote" },
 ];
 const localMetric = ref<ChartMetric>(props.modelValue ?? "cumReward");
-watch(() => props.modelValue, (v) => { if (v) localMetric.value = v; });
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (v) localMetric.value = v;
+  },
+);
 watch(localMetric, (v) => emit("update:modelValue", v));
 
 /* Smoother Updates */
 const updateOpts = { notMerge: false, lazyUpdate: true } as const;
 
 const legendSelected = computed<Record<string, boolean>>(() =>
-    Object.fromEntries(props.series.map((s) => [s.config.id, !!s.config.visible])),
+  Object.fromEntries(
+    props.series.map((s) => [s.config.id, !!s.config.visible]),
+  ),
 );
-const labelById = computed<Record<string, string>>(
-    () => Object.fromEntries(props.series.map((s) => [s.config.id, s.config.label])),
+const labelById = computed<Record<string, string>>(() =>
+  Object.fromEntries(props.series.map((s) => [s.config.id, s.config.label])),
 );
 
 /* Tween-Dauern für weiche Übergänge bei niedrigen Raten */
 const TWEEN_MS = 850;
-const INIT_MS  = 300;
+const INIT_MS = 300;
 
 const option = computed<EChartsOption>(() => {
-  const maxStep = Math.max(1, ...props.series.map((s) => s.points.cumReward.length));
+  const maxStep = Math.max(
+    1,
+    ...props.series.map((s) => s.points.cumReward.length),
+  );
 
   // Achsen als 'any' typisiert, um TS-Inkompatibilitäten zwischen ECharts-Versionen zu vermeiden
   const xAxis: any = {
@@ -138,16 +155,16 @@ const option = computed<EChartsOption>(() => {
     formatter: (params: any[]) => {
       const step = params?.[0]?.value?.[0];
       const rows = params
-          .map((p) => {
-            const label = labelById.value[p.seriesName] ?? p.seriesName;
-            return `
+        .map((p) => {
+          const label = labelById.value[p.seriesName] ?? p.seriesName;
+          return `
             <div style="display:flex;align-items:center;gap:8px;">
               <span style="width:10px;height:10px;border-radius:999px;background:${p.color};display:inline-block"></span>
               <span style="flex:1;color:#cfd3d8">${label}</span>
               <b>${fmt(p.value?.[1])}</b>
             </div>`;
-          })
-          .join("");
+        })
+        .join("");
       return `<div style="font-weight:700;margin-bottom:6px">Schritt ${step}</div>${rows}`;
     },
   };
@@ -191,7 +208,11 @@ const option = computed<EChartsOption>(() => {
       areaStyle: {
         opacity: 0.16,
         color: {
-          type: "linear", x: 0, y: 0, x2: 0, y2: 1,
+          type: "linear",
+          x: 0,
+          y: 0,
+          x2: 0,
+          y2: 1,
           colorStops: [
             { offset: 0, color: s.config.color },
             { offset: 1, color: "rgba(0,0,0,0)" },
@@ -217,31 +238,77 @@ function onLegendSelect(e: any) {
 /* Helper */
 function fmt(n: number) {
   if (!Number.isFinite(n)) return "0";
-  return Math.abs(n) >= 100 ? Math.round(n).toString() : (Math.round(n * 10) / 10).toString();
+  return Math.abs(n) >= 100
+    ? Math.round(n).toString()
+    : (Math.round(n * 10) / 10).toString();
 }
 </script>
 
 <style scoped>
-.chart-wrap { display: grid; gap: 10px; }
+.chart-wrap {
+  display: grid;
+  gap: 10px;
+}
 
 /* Toolbars */
-.chart-toolbar { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
-.metric-pills { display: flex; gap: 8px; flex-wrap: wrap; }
-.series-toolbar { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: 4px; }
+.chart-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.metric-pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.series-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 4px;
+}
 
 /* Pillen */
 .pill {
-  height: 32px; padding: 0 12px; display: inline-flex; align-items: center; gap: 8px;
-  border: 1px solid var(--line); border-radius: 999px; background: #151515; color: #d8d8d8;
-  cursor: pointer; user-select: none;
-  transition: transform var(--dur-quick) var(--ease-quick), box-shadow var(--dur-quick) var(--ease-quick),
-  background var(--dur-quick) var(--ease-quick), border-color var(--dur-quick) var(--ease-quick),
-  color var(--dur-quick) var(--ease-quick);
+  height: 32px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #151515;
+  color: #d8d8d8;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    transform var(--dur-quick) var(--ease-quick),
+    box-shadow var(--dur-quick) var(--ease-quick),
+    background var(--dur-quick) var(--ease-quick),
+    border-color var(--dur-quick) var(--ease-quick),
+    color var(--dur-quick) var(--ease-quick);
 }
-.pill:hover { transform: translateY(-1px); box-shadow: 0 6px 16px rgba(0,0,0,0.25); }
-.pill.metric.active { background: #ff0000; border-color: #ff0000; color: #fff; }
-.pill.series.off { opacity: 0.55; filter: grayscale(0.08); }
-.pill.series .dot { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
+.pill:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+.pill.metric.active {
+  background: #ff0000;
+  border-color: #ff0000;
+  color: #fff;
+}
+.pill.series.off {
+  opacity: 0.55;
+  filter: grayscale(0.08);
+}
+.pill.series .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  display: inline-block;
+}
 
 /* Chart-Container */
 .echart {

--- a/src/components/ComparisonTable.vue
+++ b/src/components/ComparisonTable.vue
@@ -1,72 +1,49 @@
 <template>
   <section class="card">
-    <!-- Header mit Toggle -->
-    <div
-      class="header"
-      @click="toggle()"
-      role="button"
-      tabindex="0"
-      @keydown.enter.prevent="toggle()"
-      @keydown.space.prevent="toggle()"
+    <!-- Header wie im Debug-Panel -->
+    <header
+        class="head"
+        role="button"
+        tabindex="0"
+        @click="toggle()"
+        @keydown.enter.prevent="toggle()"
+        @keydown.space.prevent="toggle()"
     >
-      <div class="title">
-        <span class="chev" :class="{ open }">▸</span>
-        <h2>Vergleich & Kennzahlen</h2>
+      <h2>Vergleich & Kennzahlen</h2>
+      <div class="meta">
+        <span class="badge">{{ rows.length }} Serien</span>
+        <button class="ghost" type="button">{{ open ? "Einklappen" : "Einblenden" }}</button>
       </div>
-      <div class="hint muted">{{ open ? "Einklappen" : "Ausklappen" }}</div>
-    </div>
+    </header>
 
     <transition name="fade-slide">
       <div v-if="open" class="body">
         <div class="table" role="table" aria-label="Vergleichstabelle">
           <div class="thead" role="rowgroup">
             <div class="tr head" role="row">
-              <!-- keine separate Sichtbar-Spalte mehr -->
               <div class="th col-series" role="columnheader">Serie</div>
               <div class="th col-type" role="columnheader">Typ</div>
               <div class="th" role="columnheader" title="Anzahl Züge">n</div>
-              <div class="th" role="columnheader" title="Kumulierte Belohnung">
-                Σ Reward
-              </div>
-              <div class="th" role="columnheader" title="Durchschnitts-Reward">
-                Ø Reward
-              </div>
-              <div
-                class="th"
-                role="columnheader"
-                title="Optimale Wahl in Prozent"
-              >
-                Best-Quote
-              </div>
-              <div
-                class="th"
-                role="columnheader"
-                title="Verpasster Erwartungswert (je kleiner desto besser)"
-              >
-                Regret
-              </div>
-              <div
-                class="th col-last"
-                role="columnheader"
-                title="Letzter Zug (Debug)"
-              >
-                Zuletzt
-              </div>
+              <div class="th" role="columnheader" title="Kumulierte Belohnung">Σ Reward</div>
+              <div class="th" role="columnheader" title="Durchschnitts-Reward">Ø Reward</div>
+              <div class="th" role="columnheader" title="Optimale Wahl in Prozent">Best-Quote</div>
+              <div class="th" role="columnheader" title="Verpasster Erwartungswert (je kleiner desto besser)">Regret</div>
+              <div class="th col-last" role="columnheader" title="Letzter Zug (Debug)">Zuletzt</div>
             </div>
           </div>
 
           <div class="tbody" role="rowgroup">
             <div
-              v-for="r in rows"
-              :key="r.seriesId"
-              class="tr"
-              :class="{ active: r.visible }"
-              :style="{ '--row-accent': r.color || '#ff0000' }"
-              role="row"
-              tabindex="0"
-              @click="onRowClick(r)"
-              @keydown.enter.prevent="onRowClick(r)"
-              @keydown.space.prevent="onRowClick(r)"
+                v-for="r in rows"
+                :key="r.seriesId"
+                class="tr"
+                :class="{ active: r.visible }"
+                :style="{ '--row-accent': r.color || '#ff0000' }"
+                role="row"
+                tabindex="0"
+                @click="onRowClick(r)"
+                @keydown.enter.prevent="onRowClick(r)"
+                @keydown.space.prevent="onRowClick(r)"
             >
               <div class="td col-series" role="cell">
                 <span class="dot" :style="dotStyle(r)" />
@@ -74,32 +51,23 @@
               </div>
 
               <div class="td col-type" role="cell">
-                <span class="pill" :class="r.kind">{{
-                  r.kind === "manual" ? "Manuell" : "Algorithmus"
-                }}</span>
+                <span class="pill" :class="r.kind">{{ r.kind === "manual" ? "Manuell" : "Algorithmus" }}</span>
               </div>
 
               <div class="td" role="cell">{{ r.n }}</div>
               <div class="td" role="cell">{{ fmtNum(r.cumReward) }}</div>
               <div class="td" role="cell">{{ fmtNum(r.avgReward) }}</div>
-              <div class="td" role="cell">
-                {{ (r.bestChoiceRate * 100).toFixed(1) }}%
-              </div>
+              <div class="td" role="cell">{{ (r.bestChoiceRate * 100).toFixed(1) }}%</div>
               <div class="td" role="cell">{{ fmtNum(r.regret) }}</div>
               <div class="td col-last" role="cell">
                 <span class="muted" v-if="r.lastAction == null">—</span>
-                <span v-else
-                  >Arm {{ String.fromCharCode(65 + r.lastAction) }} ·
-                  {{ fmtNum(r.lastReward ?? 0) }}</span
-                >
+                <span v-else>Arm {{ String.fromCharCode(65 + r.lastAction) }} · {{ fmtNum(r.lastReward ?? 0) }}</span>
               </div>
             </div>
           </div>
         </div>
 
-        <p class="footnote muted">
-          Fußnote, falls wir hier noch was tolles hinschreiben wollen
-        </p>
+        <p class="footnote muted">Fußnote, falls wir hier noch was tolles hinschreiben wollen</p>
       </div>
     </transition>
   </section>
@@ -109,24 +77,14 @@
 import { computed, ref, watch } from "vue";
 import type { iMetricsRow } from "../domain/iMetrics";
 
-// Props & v-model:open
-const props = defineProps<{
-  rows: iMetricsRow[];
-  open?: boolean;
-}>();
+const props = defineProps<{ rows: iMetricsRow[]; open?: boolean }>();
 const emit = defineEmits<{
   (e: "update:open", v: boolean): void;
   (e: "toggleSeries", payload: { seriesId: string; visible: boolean }): void;
 }>();
 
-// interne Open/Close-Logik
 const inner = ref<boolean>(props.open ?? true);
-watch(
-  () => props.open,
-  (v) => {
-    if (typeof v === "boolean") inner.value = v;
-  },
-);
+watch(() => props.open, (v) => { if (typeof v === "boolean") inner.value = v; });
 
 const open = computed(() => inner.value);
 function toggle() {
@@ -134,17 +92,12 @@ function toggle() {
   emit("update:open", inner.value);
 }
 
-// gesamte Zeile toggelt Sichtbarkeit (UI-only, Parent macht den eigentlichen Switch)
 function onRowClick(r: iMetricsRow) {
   emit("toggleSeries", { seriesId: r.seriesId, visible: !r.visible });
 }
 
-// farbiger Punkt – leicht abgedunkelt wenn unsichtbar
 function dotStyle(r: iMetricsRow) {
-  return {
-    background: r.color || "#888",
-    opacity: r.visible ? 1 : 0.4,
-  };
+  return { background: r.color || "#888", opacity: r.visible ? 1 : 0.4 };
 }
 
 function fmtNum(n: number) {
@@ -154,124 +107,68 @@ function fmtNum(n: number) {
 </script>
 
 <style scoped>
-.header {
+.head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 8px;
   cursor: pointer;
 }
-.title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.meta { display: flex; align-items: center; gap: 8px; }
+.badge {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #1e1e1e;
+  border: 1px solid #333;
 }
-.chev {
-  display: inline-block;
-  transform: rotate(0deg);
-  transition: transform var(--dur-quick, var(--dur-soft))
-    var(--ease-quick, var(--ease-soft));
-}
-.chev.open {
-  transform: rotate(90deg);
-}
-
-.body {
-  margin-top: 6px;
+.ghost {
+  background: #1a1a1a;
+  color: #ddd;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
 }
 
-.table {
-  width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  overflow: hidden;
-}
+.body { margin-top: 8px; }
+
+.table { width: 100%; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
 .tr {
   display: grid;
   grid-template-columns: 1.2fr 0.9fr 0.5fr 0.8fr 0.8fr 0.9fr 0.8fr 1.2fr;
   cursor: pointer;
-  transition:
-    background 160ms var(--ease-quick),
-    box-shadow 160ms var(--ease-quick),
-    filter 160ms var(--ease-quick);
+  transition: background 160ms var(--ease-quick), box-shadow 160ms var(--ease-quick), filter 160ms var(--ease-quick);
 }
-.head {
-  cursor: default;
-}
-.thead .tr {
-  background: #151515;
-  border-bottom: 1px solid var(--line);
-}
-.th,
-.td {
-  padding: 10px 12px;
-}
-.td {
-  border-top: 1px solid #202020;
-}
-.tbody .tr:hover {
-  background: #161616;
-}
+.head { cursor: default; }
+.thead .tr { background: #151515; border-bottom: 1px solid var(--line); }
+.th, .td { padding: 10px 12px; }
+.td { border-top: 1px solid #202020; }
+.tbody .tr:hover { background: #161616; }
+.tr.active { background: #191919; box-shadow: inset 4px 0 0 var(--row-accent, #ff0000); filter: saturate(1.05); }
 
-/* aktive Zeile bekommt linken Farbstreifen + leichten Lift */
-.tr.active {
-  background: #191919;
-  box-shadow: inset 4px 0 0 var(--row-accent, #ff0000);
-  filter: saturate(1.05);
-}
+.col-series { display: flex; align-items: center; gap: 8px; }
+.col-type   { white-space: nowrap; }
 
-.col-series {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.col-type {
-  white-space: nowrap;
-}
+.dot { width: 10px; height: 10px; border-radius: 999px; background: #999; display: inline-block; }
 
-/* Punkt in Serien-Spalte */
-.dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: #999;
-  display: inline-block;
-}
-
-/* Typ-Badge */
 .pill {
   font-size: 12px;
   padding: 3px 8px;
   border-radius: 999px;
   border: 1px solid var(--line);
 }
-.pill.manual {
-  background: #1c2a1c;
-  border-color: #2f5b2f;
-  color: #bfe9bf;
-}
-.pill.algo {
-  background: #1f1f2b;
-  border-color: #494970;
-  color: #cfd1ff;
-}
+.pill.manual { background: #1c2a1c; border-color: #2f5b2f; color: #bfe9bf; }
+.pill.algo   { background: #1f1f2b; border-color: #494970; color: #cfd1ff; }
 
-.footnote {
-  margin-top: 8px;
-}
+.footnote { margin-top: 8px; }
 
 /* weich ein-/ausblenden */
 .fade-slide-enter-active,
 .fade-slide-leave-active {
   transition:
-    opacity var(--dur-soft, 0.22s)
-      var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1)),
-    transform var(--dur-soft, 0.22s)
-      var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1));
+      opacity var(--dur-soft, 0.22s) var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1)),
+      transform var(--dur-soft, 0.22s) var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1));
 }
 .fade-slide-enter-from,
-.fade-slide-leave-to {
-  opacity: 0;
-  transform: translateY(6px);
-}
+.fade-slide-leave-to { opacity: 0; transform: translateY(6px); }
 </style>

--- a/src/components/ComparisonTable.vue
+++ b/src/components/ComparisonTable.vue
@@ -2,17 +2,19 @@
   <section class="card">
     <!-- Header wie im Debug-Panel -->
     <header
-        class="head"
-        role="button"
-        tabindex="0"
-        @click="toggle()"
-        @keydown.enter.prevent="toggle()"
-        @keydown.space.prevent="toggle()"
+      class="head"
+      role="button"
+      tabindex="0"
+      @click="toggle()"
+      @keydown.enter.prevent="toggle()"
+      @keydown.space.prevent="toggle()"
     >
       <h2>Vergleich & Kennzahlen</h2>
       <div class="meta">
         <span class="badge">{{ rows.length }} Serien</span>
-        <button class="ghost" type="button">{{ open ? "Einklappen" : "Einblenden" }}</button>
+        <button class="ghost" type="button">
+          {{ open ? "Einklappen" : "Einblenden" }}
+        </button>
       </div>
     </header>
 
@@ -24,26 +26,48 @@
               <div class="th col-series" role="columnheader">Serie</div>
               <div class="th col-type" role="columnheader">Typ</div>
               <div class="th" role="columnheader" title="Anzahl Züge">n</div>
-              <div class="th" role="columnheader" title="Kumulierte Belohnung">Σ Reward</div>
-              <div class="th" role="columnheader" title="Durchschnitts-Reward">Ø Reward</div>
-              <div class="th" role="columnheader" title="Optimale Wahl in Prozent">Best-Quote</div>
-              <div class="th" role="columnheader" title="Verpasster Erwartungswert (je kleiner desto besser)">Regret</div>
-              <div class="th col-last" role="columnheader" title="Letzter Zug (Debug)">Zuletzt</div>
+              <div class="th" role="columnheader" title="Kumulierte Belohnung">
+                Σ Reward
+              </div>
+              <div class="th" role="columnheader" title="Durchschnitts-Reward">
+                Ø Reward
+              </div>
+              <div
+                class="th"
+                role="columnheader"
+                title="Optimale Wahl in Prozent"
+              >
+                Best-Quote
+              </div>
+              <div
+                class="th"
+                role="columnheader"
+                title="Verpasster Erwartungswert (je kleiner desto besser)"
+              >
+                Regret
+              </div>
+              <div
+                class="th col-last"
+                role="columnheader"
+                title="Letzter Zug (Debug)"
+              >
+                Zuletzt
+              </div>
             </div>
           </div>
 
           <div class="tbody" role="rowgroup">
             <div
-                v-for="r in rows"
-                :key="r.seriesId"
-                class="tr"
-                :class="{ active: r.visible }"
-                :style="{ '--row-accent': r.color || '#ff0000' }"
-                role="row"
-                tabindex="0"
-                @click="onRowClick(r)"
-                @keydown.enter.prevent="onRowClick(r)"
-                @keydown.space.prevent="onRowClick(r)"
+              v-for="r in rows"
+              :key="r.seriesId"
+              class="tr"
+              :class="{ active: r.visible }"
+              :style="{ '--row-accent': r.color || '#ff0000' }"
+              role="row"
+              tabindex="0"
+              @click="onRowClick(r)"
+              @keydown.enter.prevent="onRowClick(r)"
+              @keydown.space.prevent="onRowClick(r)"
             >
               <div class="td col-series" role="cell">
                 <span class="dot" :style="dotStyle(r)" />
@@ -51,23 +75,32 @@
               </div>
 
               <div class="td col-type" role="cell">
-                <span class="pill" :class="r.kind">{{ r.kind === "manual" ? "Manuell" : "Algorithmus" }}</span>
+                <span class="pill" :class="r.kind">{{
+                  r.kind === "manual" ? "Manuell" : "Algorithmus"
+                }}</span>
               </div>
 
               <div class="td" role="cell">{{ r.n }}</div>
               <div class="td" role="cell">{{ fmtNum(r.cumReward) }}</div>
               <div class="td" role="cell">{{ fmtNum(r.avgReward) }}</div>
-              <div class="td" role="cell">{{ (r.bestChoiceRate * 100).toFixed(1) }}%</div>
+              <div class="td" role="cell">
+                {{ (r.bestChoiceRate * 100).toFixed(1) }}%
+              </div>
               <div class="td" role="cell">{{ fmtNum(r.regret) }}</div>
               <div class="td col-last" role="cell">
                 <span class="muted" v-if="r.lastAction == null">—</span>
-                <span v-else>Arm {{ String.fromCharCode(65 + r.lastAction) }} · {{ fmtNum(r.lastReward ?? 0) }}</span>
+                <span v-else
+                  >Arm {{ String.fromCharCode(65 + r.lastAction) }} ·
+                  {{ fmtNum(r.lastReward ?? 0) }}</span
+                >
               </div>
             </div>
           </div>
         </div>
 
-        <p class="footnote muted">Fußnote, falls wir hier noch was tolles hinschreiben wollen</p>
+        <p class="footnote muted">
+          Fußnote, falls wir hier noch was tolles hinschreiben wollen
+        </p>
       </div>
     </transition>
   </section>
@@ -84,7 +117,12 @@ const emit = defineEmits<{
 }>();
 
 const inner = ref<boolean>(props.open ?? true);
-watch(() => props.open, (v) => { if (typeof v === "boolean") inner.value = v; });
+watch(
+  () => props.open,
+  (v) => {
+    if (typeof v === "boolean") inner.value = v;
+  },
+);
 
 const open = computed(() => inner.value);
 function toggle() {
@@ -113,7 +151,11 @@ function fmtNum(n: number) {
   justify-content: space-between;
   cursor: pointer;
 }
-.meta { display: flex; align-items: center; gap: 8px; }
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 .badge {
   font-size: 12px;
   padding: 2px 8px;
@@ -130,26 +172,64 @@ function fmtNum(n: number) {
   cursor: pointer;
 }
 
-.body { margin-top: 8px; }
+.body {
+  margin-top: 8px;
+}
 
-.table { width: 100%; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.table {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+}
 .tr {
   display: grid;
   grid-template-columns: 1.2fr 0.9fr 0.5fr 0.8fr 0.8fr 0.9fr 0.8fr 1.2fr;
   cursor: pointer;
-  transition: background 160ms var(--ease-quick), box-shadow 160ms var(--ease-quick), filter 160ms var(--ease-quick);
+  transition:
+    background 160ms var(--ease-quick),
+    box-shadow 160ms var(--ease-quick),
+    filter 160ms var(--ease-quick);
 }
-.head { cursor: default; }
-.thead .tr { background: #151515; border-bottom: 1px solid var(--line); }
-.th, .td { padding: 10px 12px; }
-.td { border-top: 1px solid #202020; }
-.tbody .tr:hover { background: #161616; }
-.tr.active { background: #191919; box-shadow: inset 4px 0 0 var(--row-accent, #ff0000); filter: saturate(1.05); }
+.head {
+  cursor: default;
+}
+.thead .tr {
+  background: #151515;
+  border-bottom: 1px solid var(--line);
+}
+.th,
+.td {
+  padding: 10px 12px;
+}
+.td {
+  border-top: 1px solid #202020;
+}
+.tbody .tr:hover {
+  background: #161616;
+}
+.tr.active {
+  background: #191919;
+  box-shadow: inset 4px 0 0 var(--row-accent, #ff0000);
+  filter: saturate(1.05);
+}
 
-.col-series { display: flex; align-items: center; gap: 8px; }
-.col-type   { white-space: nowrap; }
+.col-series {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.col-type {
+  white-space: nowrap;
+}
 
-.dot { width: 10px; height: 10px; border-radius: 999px; background: #999; display: inline-block; }
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #999;
+  display: inline-block;
+}
 
 .pill {
   font-size: 12px;
@@ -157,18 +237,33 @@ function fmtNum(n: number) {
   border-radius: 999px;
   border: 1px solid var(--line);
 }
-.pill.manual { background: #1c2a1c; border-color: #2f5b2f; color: #bfe9bf; }
-.pill.algo   { background: #1f1f2b; border-color: #494970; color: #cfd1ff; }
+.pill.manual {
+  background: #1c2a1c;
+  border-color: #2f5b2f;
+  color: #bfe9bf;
+}
+.pill.algo {
+  background: #1f1f2b;
+  border-color: #494970;
+  color: #cfd1ff;
+}
 
-.footnote { margin-top: 8px; }
+.footnote {
+  margin-top: 8px;
+}
 
 /* weich ein-/ausblenden */
 .fade-slide-enter-active,
 .fade-slide-leave-active {
   transition:
-      opacity var(--dur-soft, 0.22s) var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1)),
-      transform var(--dur-soft, 0.22s) var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1));
+    opacity var(--dur-soft, 0.22s)
+      var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1)),
+    transform var(--dur-soft, 0.22s)
+      var(--ease-soft, cubic-bezier(0.22, 0.61, 0.36, 1));
 }
 .fade-slide-enter-from,
-.fade-slide-leave-to { opacity: 0; transform: translateY(6px); }
+.fade-slide-leave-to {
+  opacity: 0;
+  transform: translateY(6px);
+}
 </style>

--- a/src/components/RunnerControls.vue
+++ b/src/components/RunnerControls.vue
@@ -13,21 +13,29 @@
     <div class="form-grid">
       <div class="col-4">
         <NumericStepper
-            v-model="totalSteps"
-            label="Ziel-Iterationen (n)"
-            :min="1"
-            :step="1"
-            @bump="(p) => pushLog(`n ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}`)"
+          v-model="totalSteps"
+          label="Ziel-Iterationen (n)"
+          :min="1"
+          :step="1"
+          @bump="
+            (p) =>
+              pushLog(`n ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}`)
+          "
         />
       </div>
 
       <div class="col-4">
         <NumericStepper
-            v-model="rate"
-            label="Rate (Schritte/Sek.)"
-            :min="1"
-            :step="1"
-            @bump="(p) => pushLog(`Rate ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}/s`)"
+          v-model="rate"
+          label="Rate (Schritte/Sek.)"
+          :min="1"
+          :step="1"
+          @bump="
+            (p) =>
+              pushLog(
+                `Rate ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}/s`,
+              )
+          "
         />
       </div>
 
@@ -39,21 +47,21 @@
         <!-- EnvSetup-Style: segmentierte Gruppe -->
         <div class="control-group group-2">
           <button
-              class="group-btn"
-              type="button"
-              :disabled="!envId"
-              @click="onConfigure"
-              title="Konfiguration aus Environment übernehmen"
+            class="group-btn"
+            type="button"
+            :disabled="!envId"
+            @click="onConfigure"
+            title="Konfiguration aus Environment übernehmen"
           >
             Konfigurieren
           </button>
 
           <button
-              class="group-btn"
-              type="button"
-              :disabled="!canStep"
-              @click="onStep"
-              title="Einen Schritt ausführen"
+            class="group-btn"
+            type="button"
+            :disabled="!canStep"
+            @click="onStep"
+            title="Einen Schritt ausführen"
           >
             +1 Schritt
           </button>
@@ -62,24 +70,36 @@
         <!-- Play/Pause: runder Button, auf gleicher Zeile, vertikal zentriert -->
         <div class="fab-inline">
           <button
-              class="fab"
-              :class="fabClass"
-              type="button"
-              :disabled="!canToggle"
-              @click="onToggleRun"
-              :aria-label="running ? 'Pausieren' : 'Starten'"
-              :title="running ? 'Pausieren' : 'Starten'"
+            class="fab"
+            :class="fabClass"
+            type="button"
+            :disabled="!canToggle"
+            @click="onToggleRun"
+            :aria-label="running ? 'Pausieren' : 'Starten'"
+            :title="running ? 'Pausieren' : 'Starten'"
           >
             <!-- Play -->
-            <svg v-if="!running" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
-              <path d="M8 5v14l11-7z" fill="currentColor"/>
+            <svg
+              v-if="!running"
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              aria-hidden="true"
+            >
+              <path d="M8 5v14l11-7z" fill="currentColor" />
             </svg>
             <!-- Pause -->
-            <svg v-else viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-              <path d="M6 5h4v14H6zM14 5h4v14h-4z" fill="currentColor"/>
+            <svg
+              v-else
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              aria-hidden="true"
+            >
+              <path d="M6 5h4v14H6zM14 5h4v14h-4z" fill="currentColor" />
             </svg>
           </button>
-          <span class="fab-label">{{ running ? 'Pause' : 'Start' }}</span>
+          <span class="fab-label">{{ running ? "Pause" : "Start" }}</span>
         </div>
       </div>
     </div>
@@ -121,7 +141,10 @@ function pushLog(line: string) {
   logBuf.push(`[${ts}] ${line}`);
   if (rafPending) return;
   rafPending = true;
-  requestAnimationFrame(() => { rafPending = false; flushLogs(); });
+  requestAnimationFrame(() => {
+    rafPending = false;
+    flushLogs();
+  });
 }
 
 /* Ergebnis-Logs drosseln */
@@ -139,7 +162,10 @@ const off = algorithmsRunner.on((msg) => {
       running.value = false;
       currentStep.value = 0;
       statusText.value = "Konfiguriert";
-      logEvery.value = msg.payload.totalSteps > 0 ? Math.max(1, Math.floor(msg.payload.totalSteps / 40)) : 10;
+      logEvery.value =
+        msg.payload.totalSteps > 0
+          ? Math.max(1, Math.floor(msg.payload.totalSteps / 40))
+          : 10;
       pushLog(`Ziel ${msg.payload.totalSteps}, Rate ${msg.payload.rate}/s`);
       break;
     case "STARTED":
@@ -162,7 +188,7 @@ const off = algorithmsRunner.on((msg) => {
       const t = msg.payload.total;
       if (s <= 3 || s % logEvery.value === 0 || (t > 0 && s === t)) {
         pushLog(
-            `#${s}/${t} · ${msg.payload.policyId} → Arm ${msg.payload.action} · r=${msg.payload.reward.toFixed(2)}${msg.payload.isOptimal ? " (optimal)" : ""}`,
+          `#${s}/${t} · ${msg.payload.policyId} → Arm ${msg.payload.action} · r=${msg.payload.reward.toFixed(2)}${msg.payload.isOptimal ? " (optimal)" : ""}`,
         );
       }
       currentStep.value = s;
@@ -179,15 +205,27 @@ const off = algorithmsRunner.on((msg) => {
   }
 });
 
-const canStart  = computed(() => configured.value && !running.value && currentStep.value < totalSteps.value);
-const canStep   = computed(() => configured.value && !running.value && currentStep.value < totalSteps.value);
+const canStart = computed(
+  () =>
+    configured.value && !running.value && currentStep.value < totalSteps.value,
+);
+const canStep = computed(
+  () =>
+    configured.value && !running.value && currentStep.value < totalSteps.value,
+);
 const canToggle = computed(() => running.value || canStart.value);
 
 /* Statusklassen */
 const statusClass = computed(() => {
   if (running.value) return "is-running";
-  if (configured.value && currentStep.value >= totalSteps.value && totalSteps.value > 0) return "is-stopped";
-  if (configured.value && !running.value && currentStep.value > 0) return "is-paused";
+  if (
+    configured.value &&
+    currentStep.value >= totalSteps.value &&
+    totalSteps.value > 0
+  )
+    return "is-stopped";
+  if (configured.value && !running.value && currentStep.value > 0)
+    return "is-paused";
   return "is-ready";
 });
 const fabClass = computed(() => ({
@@ -213,19 +251,36 @@ async function onConfigure() {
   running.value = false;
   currentStep.value = 0;
   statusText.value = "Konfiguriert";
-  pushLog(`Konfiguriert: n=${totalSteps.value}, rate=${rate.value}/s, arms=${snap?.config?.arms ?? "?"}`);
+  pushLog(
+    `Konfiguriert: n=${totalSteps.value}, rate=${rate.value}/s, arms=${snap?.config?.arms ?? "?"}`,
+  );
 }
 
 /* Start/Pause */
-function onStart() { if (canStart.value) algorithmsRunner.start(); }
-function onPause() { algorithmsRunner.pause(); }
-function onToggleRun() { running.value ? onPause() : onStart(); }
+function onStart() {
+  if (canStart.value) algorithmsRunner.start();
+}
+function onPause() {
+  algorithmsRunner.pause();
+}
+function onToggleRun() {
+  running.value ? onPause() : onStart();
+}
 
 /* Einzelschritt */
 function onStep() {
-  if (!configured.value) { pushLog("Bitte zuerst konfigurieren."); return; }
-  if (running.value)     { pushLog("Während des Laufs sind Einzelschritte gesperrt."); return; }
-  if (currentStep.value >= totalSteps.value) { pushLog("Ziel erreicht. Bitte neu konfigurieren oder n erhöhen."); return; }
+  if (!configured.value) {
+    pushLog("Bitte zuerst konfigurieren.");
+    return;
+  }
+  if (running.value) {
+    pushLog("Während des Laufs sind Einzelschritte gesperrt.");
+    return;
+  }
+  if (currentStep.value >= totalSteps.value) {
+    pushLog("Ziel erreicht. Bitte neu konfigurieren oder n erhöhen.");
+    return;
+  }
   algorithmsRunner.stepOnce();
 }
 
@@ -252,18 +307,32 @@ onBeforeUnmount(() => {
   font-size: 12px;
   line-height: 1;
   border: 1px solid #2a2a2a;
-  background: rgba(255,255,255,0.04);
+  background: rgba(255, 255, 255, 0.04);
   color: #d9d9d9;
 }
 .head-status .dot {
-  width: 8px; height: 8px; border-radius: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   background: #9ca3af;
-  box-shadow: 0 0 0 2px rgba(156,163,175,0.25);
+  box-shadow: 0 0 0 2px rgba(156, 163, 175, 0.25);
 }
-.head-status.is-ready  .dot { background:#9ca3af; box-shadow:0 0 0 2px rgba(156,163,175,.25); }
-.head-status.is-running .dot { background:#2563eb; box-shadow:0 0 0 2px rgba(37,99,235,.25); }
-.head-status.is-paused  .dot { background:#f59e0b; box-shadow:0 0 0 2px rgba(245,158,11,.25); }
-.head-status.is-stopped .dot { background:#ef4444; box-shadow:0 0 0 2px rgba(239,68,68,.25); }
+.head-status.is-ready .dot {
+  background: #9ca3af;
+  box-shadow: 0 0 0 2px rgba(156, 163, 175, 0.25);
+}
+.head-status.is-running .dot {
+  background: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
+.head-status.is-paused .dot {
+  background: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.25);
+}
+.head-status.is-stopped .dot {
+  background: #ef4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.25);
+}
 
 /* Grid analog EnvSetup */
 .form-grid {
@@ -272,11 +341,19 @@ onBeforeUnmount(() => {
   gap: 12px;
   align-items: end;
 }
-.col-4 { grid-column: span 4; }
-@media (max-width: 980px) { .col-4 { grid-column: 1 / -1; } }
+.col-4 {
+  grid-column: span 4;
+}
+@media (max-width: 980px) {
+  .col-4 {
+    grid-column: 1 / -1;
+  }
+}
 
 /* Actions-Zeile */
-.actions { margin-top: 12px; }
+.actions {
+  margin-top: 12px;
+}
 .control-row {
   display: flex;
   align-items: center; /* vertikal zentriert: FAB auf einer Ebene */
@@ -285,59 +362,117 @@ onBeforeUnmount(() => {
 
 /* Segmentierte Gruppe – EnvSetup-Style */
 .control-group {
-  height: 44px; flex: 1;
-  display: grid; background: #111;
-  border: 1px solid #333; border-radius: 10px; overflow: hidden;
+  height: 44px;
+  flex: 1;
+  display: grid;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 10px;
+  overflow: hidden;
 }
-.group-2 { grid-template-columns: 1fr 1fr; }
+.group-2 {
+  grid-template-columns: 1fr 1fr;
+}
 
 .group-btn {
-  height: 42px; background: #1a1a1a; color: #fff;
-  border: 0; border-right: 1px solid #333; cursor: pointer;
-  padding: 0 12px; text-align: center; display: inline-flex;
-  align-items: center; justify-content: center; font-weight: 600;
+  height: 42px;
+  background: #1a1a1a;
+  color: #fff;
+  border: 0;
+  border-right: 1px solid #333;
+  cursor: pointer;
+  padding: 0 12px;
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
 }
-.group-btn:last-child { border-right: 0; }
-.group-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.group-btn:last-child {
+  border-right: 0;
+}
+.group-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 
 /* FAB + Label inline */
-.fab-inline { display: inline-flex; align-items: center; gap: 8px; }
+.fab-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
 
 /* Play/Pause: runder Button (YT-rot idle, Blau running, Amber pausiert) */
 .fab {
   --yt-red: #ff0000;
   --run-blue: #2563eb;
   --pause-amber: #f59e0b;
-  width: 56px; height: 56px; border-radius: 999px;
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
   border: 2px solid var(--yt-red);
-  background: rgba(255,255,255,0.06);
+  background: rgba(255, 255, 255, 0.06);
   backdrop-filter: saturate(140%) blur(6px);
   -webkit-backdrop-filter: saturate(140%) blur(6px);
-  display: inline-flex; align-items: center; justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--yt-red);
   box-shadow:
-      0 0 0 4px rgba(255,0,0,0.12),
-      inset 0 1px 0 rgba(255,255,255,0.08);
-  transition: transform .06s ease, box-shadow .2s ease, color .15s ease, border-color .15s ease, background-color .15s ease;
+    0 0 0 4px rgba(255, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  transition:
+    transform 0.06s ease,
+    box-shadow 0.2s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
 }
-.fab:not(:disabled):hover { box-shadow: 0 0 0 6px rgba(255,0,0,0.16), inset 0 1px 0 rgba(255,255,255,0.10); }
-.fab:active:not(:disabled) { transform: scale(0.97); }
-.fab:disabled { opacity: .5; cursor: not-allowed; }
+.fab:not(:disabled):hover {
+  box-shadow:
+    0 0 0 6px rgba(255, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+.fab:active:not(:disabled) {
+  transform: scale(0.97);
+}
+.fab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 .fab.running {
   color: var(--run-blue);
   border-color: var(--run-blue);
-  box-shadow: 0 0 0 4px rgba(37,99,235,0.16), inset 0 1px 0 rgba(255,255,255,0.10);
+  box-shadow:
+    0 0 0 4px rgba(37, 99, 235, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 .fab.paused {
   color: var(--pause-amber);
   border-color: var(--pause-amber);
-  box-shadow: 0 0 0 4px rgba(245,158,11,0.16), inset 0 1px 0 rgba(255,255,255,0.10);
+  box-shadow:
+    0 0 0 4px rgba(245, 158, 11, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 
-.fab-label { font-size: 12px; color: #cfcfcf; user-select: none; }
+.fab-label {
+  font-size: 12px;
+  color: #cfcfcf;
+  user-select: none;
+}
 
 /* Log-Ausgabe */
-.out .label { font-size: 12px; opacity: 0.7; }
-.pre { background: #151515; border: 1px solid #2a2a2a; border-radius: 10px; padding: 10px; overflow: auto; }
+.out .label {
+  font-size: 12px;
+  opacity: 0.7;
+}
+.pre {
+  background: #151515;
+  border: 1px solid #2a2a2a;
+  border-radius: 10px;
+  padding: 10px;
+  overflow: auto;
+}
 </style>

--- a/src/components/RunnerControls.vue
+++ b/src/components/RunnerControls.vue
@@ -1,305 +1,343 @@
 <template>
   <section class="card">
-    <h2>Automatischer Lauf (Algorithmen kommen später)</h2>
-
-    <!-- Kopf: zwei einheitliche Stepper -->
-    <div class="grid">
-      <div>
-        <NumericStepper
-          v-model="totalSteps"
-          label="Ziel-Iterationen (n)"
-          :min="1"
-          :step="1"
-          @bump="
-            (p) =>
-              pushLog(`n ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}`)
-          "
-        />
+    <!-- Titel + Status rechts daneben -->
+    <div class="card-head head-with-status">
+      <h2>Automatischer Lauf</h2>
+      <div class="head-status" :class="statusClass" title="Runner-Status">
+        <span class="dot" />
+        <span class="txt">{{ statusText }}</span>
       </div>
-      <div>
-        <NumericStepper
-          v-model="rate"
-          label="Rate (n pro Sekunde)"
-          :min="1"
-          :step="1"
-          @bump="
-            (p) =>
-              pushLog(
-                `Rate ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}/s`,
-              )
-          "
-        />
-      </div>
-
-      <!-- Platzhalter-Spalte, damit das Grid visuell ruhig bleibt -->
-      <div class="placeholder"></div>
     </div>
 
-    <!-- Aktionsleiste -->
-    <div class="actions">
-      <div class="control-group group-4">
-        <button
-          class="group-btn"
-          type="button"
-          :disabled="!envId"
-          @click="onConfigure"
-        >
-          Konfigurieren
-        </button>
-
-        <button
-          class="group-btn"
-          type="button"
-          :disabled="!envId || running"
-          @click="onStep"
-        >
-          +1 Schritt
-        </button>
-
-        <button
-          class="group-btn primary"
-          type="button"
-          :disabled="!envId || running"
-          @click="onStart"
-        >
-          Start
-        </button>
-
-        <button
-          class="group-btn ghost"
-          type="button"
-          :disabled="!envId || !running"
-          @click="onPause"
-        >
-          Pause
-        </button>
+    <!-- Grid wie im EnvSetup -->
+    <div class="form-grid">
+      <div class="col-4">
+        <NumericStepper
+            v-model="totalSteps"
+            label="Ziel-Iterationen (n)"
+            :min="1"
+            :step="1"
+            @bump="(p) => pushLog(`n ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}`)"
+        />
       </div>
 
-      <span class="muted status" v-if="statusText"
-        >Status: {{ statusText }}</span
-      >
+      <div class="col-4">
+        <NumericStepper
+            v-model="rate"
+            label="Rate (Schritte/Sek.)"
+            :min="1"
+            :step="1"
+            @bump="(p) => pushLog(`Rate ${p.delta > 0 ? 'erhöht' : 'verringert'} → ${p.value}/s`)"
+        />
+      </div>
+
+      <div class="col-4"></div>
+    </div>
+
+    <div class="actions">
+      <div class="control-row">
+        <!-- EnvSetup-Style: segmentierte Gruppe -->
+        <div class="control-group group-2">
+          <button
+              class="group-btn"
+              type="button"
+              :disabled="!envId"
+              @click="onConfigure"
+              title="Konfiguration aus Environment übernehmen"
+          >
+            Konfigurieren
+          </button>
+
+          <button
+              class="group-btn"
+              type="button"
+              :disabled="!canStep"
+              @click="onStep"
+              title="Einen Schritt ausführen"
+          >
+            +1 Schritt
+          </button>
+        </div>
+
+        <!-- Play/Pause: runder Button, auf gleicher Zeile, vertikal zentriert -->
+        <div class="fab-inline">
+          <button
+              class="fab"
+              :class="fabClass"
+              type="button"
+              :disabled="!canToggle"
+              @click="onToggleRun"
+              :aria-label="running ? 'Pausieren' : 'Starten'"
+              :title="running ? 'Pausieren' : 'Starten'"
+          >
+            <!-- Play -->
+            <svg v-if="!running" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+              <path d="M8 5v14l11-7z" fill="currentColor"/>
+            </svg>
+            <!-- Pause -->
+            <svg v-else viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path d="M6 5h4v14H6zM14 5h4v14h-4z" fill="currentColor"/>
+            </svg>
+          </button>
+          <span class="fab-label">{{ running ? 'Pause' : 'Start' }}</span>
+        </div>
+      </div>
     </div>
 
     <div class="out">
       <div class="label">Protokoll</div>
-      <pre class="pre" style="max-height: 220px">{{ logText }}</pre>
+      <pre class="pre" style="max-height: 240px">{{ logText }}</pre>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from "vue";
+import { ref, computed, onBeforeUnmount } from "vue";
 import NumericStepper from "./ui/NumericStepper.vue";
+import { algorithmsRunner } from "../services/algorithmsRunner";
+import { getEnvSnapshot } from "../api/banditClient";
 
 const props = defineProps<{ envId: string | null; arms: number }>();
 
 const totalSteps = ref<number>(100);
 const rate = ref<number>(5);
 
-const statusText = ref<string>(""); // „Bereit“, „Konfiguriert“, „Läuft“, „Pausiert“
-const running = ref<boolean>(false); // steuert Start/Pause
-const logs: string[] = [];
+const statusText = ref<string>("Bereit");
+const configured = ref<boolean>(false);
+const running = ref<boolean>(false);
+const currentStep = ref<number>(0);
+
+/* rAF-gepufferte Logs */
 const logText = ref<string>("");
-
-let worker: Worker | null = null;
-
-watch(
-  () => props.envId,
-  (id) => {
-    if (!id) {
-      statusText.value = "Kein Environment";
-      running.value = false;
-      return;
-    }
-    ensureWorker();
-    statusText.value = "Bereit";
-  },
-);
-
-function ensureWorker() {
-  if (worker) return;
-  worker = new Worker(new URL("../workers/banditWorkers.ts", import.meta.url), {
-    type: "module",
-  });
-
-  worker.addEventListener("message", (e: MessageEvent) => {
-    const msg = e.data;
-
-    switch (msg.type) {
-      case "READY":
-        pushLog("Worker bereit.");
-        break;
-
-      case "CONFIGURED":
-        pushLog(
-          `Konfiguriert: env=${msg.payload.envId.substring(0, 8)} steps=${msg.payload.totalSteps} rate=${msg.payload.rate}/s`,
-        );
-        statusText.value = "Konfiguriert";
-        running.value = false; // falls zwischendrin geklickt wurde -> neutralisieren
-        break;
-
-      case "STARTED":
-        statusText.value = "Läuft";
-        running.value = true;
-        pushLog("Lauf gestartet.");
-        break;
-
-      case "STOPPED": {
-        const reason = msg.payload?.reason ?? "";
-        const isPause =
-          reason === "Manuell gestoppt" ||
-          reason === "" ||
-          reason.startsWith("Ziel");
-        statusText.value = isPause ? "Pausiert" : "Gestoppt";
-        running.value = false;
-        pushLog(`Lauf angehalten. ${reason}`.trim());
-        break;
-      }
-
-      case "REQUEST_ACTION":
-        {
-          //erweitern, sobald algorithmen implementiert sind.
-        }
-        break;
-
-      case "RESULT":
-        // später kommen hier mehrere Serien rein; heute reicht die Ausgabe
-        pushLog(
-          `Schritt ${msg.payload.step}: Arm ${msg.payload.action} → Reward ${msg.payload.reward.toFixed(2)} (${msg.payload.isOptimal ? "optimal" : "—"})`,
-        );
-        break;
-
-      case "PROGRESS":
-        pushLog(
-          `Fortschritt: ${msg.payload.step}/${msg.payload.total} (rest ${msg.payload.remaining})`,
-        );
-        break;
-
-      case "ERROR":
-        pushError(msg.payload.message);
-        running.value = false;
-        break;
-
-      default:
-        pushError("Unbekannte Worker-Antwort.");
-    }
-  });
+let logBuf: string[] = [];
+let rafPending = false;
+function flushLogs() {
+  if (!logBuf.length) return;
+  logText.value += logBuf.join("\n") + "\n";
+  logBuf = [];
 }
-
-function onConfigure() {
-  if (!props.envId) return;
-  ensureWorker();
-  running.value = false;
-  pushLog(`Konfigurieren → n=${totalSteps.value}, rate=${rate.value}/s`);
-  worker!.postMessage({
-    type: "CONFIGURE",
-    payload: {
-      envId: props.envId,
-      totalSteps: totalSteps.value,
-      rate: rate.value,
-    },
-  });
-}
-
-function onStart() {
-  if (!props.envId) return;
-  ensureWorker();
-  pushLog("Start");
-  worker!.postMessage({ type: "START" });
-}
-
-function onPause() {
-  if (!props.envId) return;
-  ensureWorker();
-  pushLog("Pause");
-  worker!.postMessage({ type: "STOP" }); // Worker interpretiert „STOP“ als anhalten
-}
-
-function onStep() {
-  if (!props.envId) return;
-  ensureWorker();
-  pushLog("Einzelschritt");
-  worker!.postMessage({ type: "STEP" });
-}
-
 function pushLog(line: string) {
-  logs.unshift(`• ${line}`);
-  logText.value = logs.slice(0, 80).join("\n");
+  const ts = new Date().toLocaleTimeString();
+  logBuf.push(`[${ts}] ${line}`);
+  if (rafPending) return;
+  rafPending = true;
+  requestAnimationFrame(() => { rafPending = false; flushLogs(); });
 }
-function pushError(line: string) {
-  pushLog(`FEHLER: ${line}`);
+
+/* Ergebnis-Logs drosseln */
+const logEvery = ref<number>(5);
+
+/* Runner-Events */
+const off = algorithmsRunner.on((msg) => {
+  switch (msg.type) {
+    case "READY":
+      statusText.value = "Bereit";
+      pushLog("Runner bereit.");
+      break;
+    case "CONFIGURED":
+      configured.value = true;
+      running.value = false;
+      currentStep.value = 0;
+      statusText.value = "Konfiguriert";
+      logEvery.value = msg.payload.totalSteps > 0 ? Math.max(1, Math.floor(msg.payload.totalSteps / 40)) : 10;
+      pushLog(`Ziel ${msg.payload.totalSteps}, Rate ${msg.payload.rate}/s`);
+      break;
+    case "STARTED":
+      running.value = true;
+      statusText.value = "Läuft";
+      pushLog("Lauf gestartet.");
+      break;
+    case "PAUSED":
+      running.value = false;
+      statusText.value = "Pausiert";
+      pushLog("Pausiert.");
+      break;
+    case "STOPPED":
+      running.value = false;
+      statusText.value = "Gestoppt";
+      pushLog(`Lauf angehalten. ${msg.payload.reason}`);
+      break;
+    case "RESULT": {
+      const s = msg.payload.step;
+      const t = msg.payload.total;
+      if (s <= 3 || s % logEvery.value === 0 || (t > 0 && s === t)) {
+        pushLog(
+            `#${s}/${t} · ${msg.payload.policyId} → Arm ${msg.payload.action} · r=${msg.payload.reward.toFixed(2)}${msg.payload.isOptimal ? " (optimal)" : ""}`,
+        );
+      }
+      currentStep.value = s;
+      break;
+    }
+    case "LOG":
+      pushLog(msg.payload.message);
+      break;
+    case "PROGRESS":
+      break;
+    case "ERROR":
+      pushLog(`FEHLER: ${msg.payload.message}`);
+      break;
+  }
+});
+
+const canStart  = computed(() => configured.value && !running.value && currentStep.value < totalSteps.value);
+const canStep   = computed(() => configured.value && !running.value && currentStep.value < totalSteps.value);
+const canToggle = computed(() => running.value || canStart.value);
+
+/* Statusklassen */
+const statusClass = computed(() => {
+  if (running.value) return "is-running";
+  if (configured.value && currentStep.value >= totalSteps.value && totalSteps.value > 0) return "is-stopped";
+  if (configured.value && !running.value && currentStep.value > 0) return "is-paused";
+  return "is-ready";
+});
+const fabClass = computed(() => ({
+  running: running.value,
+  paused: !running.value && configured.value && currentStep.value > 0,
+}));
+
+/* Konfiguration übernehmen */
+async function onConfigure() {
+  if (!props.envId) {
+    statusText.value = "Kein Environment";
+    pushLog("Kein Environment vorhanden.");
+    return;
+  }
+  const snap: any = await getEnvSnapshot(props.envId);
+  algorithmsRunner.configure({
+    envConfig: snap.config,
+    totalSteps: totalSteps.value,
+    rate: rate.value,
+  });
+
+  configured.value = true;
+  running.value = false;
+  currentStep.value = 0;
+  statusText.value = "Konfiguriert";
+  pushLog(`Konfiguriert: n=${totalSteps.value}, rate=${rate.value}/s, arms=${snap?.config?.arms ?? "?"}`);
+}
+
+/* Start/Pause */
+function onStart() { if (canStart.value) algorithmsRunner.start(); }
+function onPause() { algorithmsRunner.pause(); }
+function onToggleRun() { running.value ? onPause() : onStart(); }
+
+/* Einzelschritt */
+function onStep() {
+  if (!configured.value) { pushLog("Bitte zuerst konfigurieren."); return; }
+  if (running.value)     { pushLog("Während des Laufs sind Einzelschritte gesperrt."); return; }
+  if (currentStep.value >= totalSteps.value) { pushLog("Ziel erreicht. Bitte neu konfigurieren oder n erhöhen."); return; }
+  algorithmsRunner.stepOnce();
 }
 
 onBeforeUnmount(() => {
-  if (worker) {
-    worker.terminate();
-    worker = null;
-  }
+  off();
+  algorithmsRunner.pause();
 });
 </script>
 
 <style scoped>
-.grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-}
-.placeholder {
-  /* einfach leer lassen, tut nur fürs Layout */
-}
-
-.control {
-  height: 44px;
-  width: 100%;
-  background: #111;
-  color: #eee;
-  border: 1px solid #333;
-  border-radius: 10px;
-  padding: 0 12px;
-}
-
-.actions {
+/* Kopf mit Status rechts */
+.head-with-status {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-top: 12px;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
 }
-.control-group {
-  height: 44px;
-  width: 100%;
+.head-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1;
+  border: 1px solid #2a2a2a;
+  background: rgba(255,255,255,0.04);
+  color: #d9d9d9;
+}
+.head-status .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #9ca3af;
+  box-shadow: 0 0 0 2px rgba(156,163,175,0.25);
+}
+.head-status.is-ready  .dot { background:#9ca3af; box-shadow:0 0 0 2px rgba(156,163,175,.25); }
+.head-status.is-running .dot { background:#2563eb; box-shadow:0 0 0 2px rgba(37,99,235,.25); }
+.head-status.is-paused  .dot { background:#f59e0b; box-shadow:0 0 0 2px rgba(245,158,11,.25); }
+.head-status.is-stopped .dot { background:#ef4444; box-shadow:0 0 0 2px rgba(239,68,68,.25); }
+
+/* Grid analog EnvSetup */
+.form-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  background: #111;
-  border: 1px solid #333;
-  border-radius: 10px;
-  overflow: hidden;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 12px;
+  align-items: end;
 }
-.group-btn {
-  height: 42px;
-  background: #1a1a1a;
-  color: #fff;
-  border: 0;
-  border-right: 1px solid #333;
-  cursor: pointer;
-  padding: 0 12px;
-}
-.group-btn:last-child {
-  border-right: 0;
-}
-.group-btn.primary {
-  background: #ff0000;
-  border-right: 1px solid #ff0000;
-}
-.group-btn.ghost {
-  background: #2a1b1b;
-}
-.group-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.col-4 { grid-column: span 4; }
+@media (max-width: 980px) { .col-4 { grid-column: 1 / -1; } }
+
+/* Actions-Zeile */
+.actions { margin-top: 12px; }
+.control-row {
+  display: flex;
+  align-items: center; /* vertikal zentriert: FAB auf einer Ebene */
+  gap: 14px;
 }
 
-.status {
-  white-space: nowrap;
+/* Segmentierte Gruppe – EnvSetup-Style */
+.control-group {
+  height: 44px; flex: 1;
+  display: grid; background: #111;
+  border: 1px solid #333; border-radius: 10px; overflow: hidden;
 }
+.group-2 { grid-template-columns: 1fr 1fr; }
+
+.group-btn {
+  height: 42px; background: #1a1a1a; color: #fff;
+  border: 0; border-right: 1px solid #333; cursor: pointer;
+  padding: 0 12px; text-align: center; display: inline-flex;
+  align-items: center; justify-content: center; font-weight: 600;
+}
+.group-btn:last-child { border-right: 0; }
+.group-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* FAB + Label inline */
+.fab-inline { display: inline-flex; align-items: center; gap: 8px; }
+
+/* Play/Pause: runder Button (YT-rot idle, Blau running, Amber pausiert) */
+.fab {
+  --yt-red: #ff0000;
+  --run-blue: #2563eb;
+  --pause-amber: #f59e0b;
+  width: 56px; height: 56px; border-radius: 999px;
+  border: 2px solid var(--yt-red);
+  background: rgba(255,255,255,0.06);
+  backdrop-filter: saturate(140%) blur(6px);
+  -webkit-backdrop-filter: saturate(140%) blur(6px);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--yt-red);
+  box-shadow:
+      0 0 0 4px rgba(255,0,0,0.12),
+      inset 0 1px 0 rgba(255,255,255,0.08);
+  transition: transform .06s ease, box-shadow .2s ease, color .15s ease, border-color .15s ease, background-color .15s ease;
+}
+.fab:not(:disabled):hover { box-shadow: 0 0 0 6px rgba(255,0,0,0.16), inset 0 1px 0 rgba(255,255,255,0.10); }
+.fab:active:not(:disabled) { transform: scale(0.97); }
+.fab:disabled { opacity: .5; cursor: not-allowed; }
+
+.fab.running {
+  color: var(--run-blue);
+  border-color: var(--run-blue);
+  box-shadow: 0 0 0 4px rgba(37,99,235,0.16), inset 0 1px 0 rgba(255,255,255,0.10);
+}
+.fab.paused {
+  color: var(--pause-amber);
+  border-color: var(--pause-amber);
+  box-shadow: 0 0 0 4px rgba(245,158,11,0.16), inset 0 1px 0 rgba(255,255,255,0.10);
+}
+
+.fab-label { font-size: 12px; color: #cfcfcf; user-select: none; }
+
+/* Log-Ausgabe */
+.out .label { font-size: 12px; opacity: 0.7; }
+.pre { background: #151515; border: 1px solid #2a2a2a; border-radius: 10px; padding: 10px; overflow: auto; }
 </style>

--- a/src/services/algorithmsRunner.ts
+++ b/src/services/algorithmsRunner.ts
@@ -11,261 +11,287 @@ import { GaussianBanditEnv } from "../env/GaussianBanditEnv";
 export type PolicyId = "greedy" | "epsgreedy";
 
 export type PolicyMeta = {
-    id: PolicyId;
-    label: string;
-    color: string;
-    policy: iBanditPolicy;
-    env: iBanditEnv;
-    history: Array<{ action: number; reward: number; isOptimal: boolean }>;
-    visible?: boolean;
+  id: PolicyId;
+  label: string;
+  color: string;
+  policy: iBanditPolicy;
+  env: iBanditEnv;
+  history: Array<{ action: number; reward: number; isOptimal: boolean }>;
+  visible?: boolean;
 };
 
 export type RunnerConfig = {
-    envConfig: iEnvConfig;
-    totalSteps: number;
-    rate: number; // steps/second
-    policyConfigs?: Partial<Record<PolicyId, iBanditPolicyConfig>>;
+  envConfig: iEnvConfig;
+  totalSteps: number;
+  rate: number; // steps/second
+  policyConfigs?: Partial<Record<PolicyId, iBanditPolicyConfig>>;
 };
 
-export type RunnerStatus = "IDLE" | "CONFIGURED" | "RUNNING" | "PAUSED" | "STOPPED";
+export type RunnerStatus =
+  | "IDLE"
+  | "CONFIGURED"
+  | "RUNNING"
+  | "PAUSED"
+  | "STOPPED";
 
 export type RunnerEvent =
-    | { type: "READY" }
-    | { type: "CONFIGURED"; payload: { totalSteps: number; rate: number } }
-    | { type: "STARTED" }
-    | { type: "PAUSED" }
-    | { type: "STOPPED"; payload: { reason: string } }
-    | {
-    type: "RESULT";
-    payload: {
+  | { type: "READY" }
+  | { type: "CONFIGURED"; payload: { totalSteps: number; rate: number } }
+  | { type: "STARTED" }
+  | { type: "PAUSED" }
+  | { type: "STOPPED"; payload: { reason: string } }
+  | {
+      type: "RESULT";
+      payload: {
         policyId: PolicyId;
         step: number;
         total: number;
         action: number;
         reward: number;
         isOptimal: boolean;
-    };
-}
-    | { type: "PROGRESS"; payload: { step: number; remaining: number; total: number } }
-    | { type: "LOG"; payload: { message: string } }
-    | { type: "ERROR"; payload: { message: string } };
+      };
+    }
+  | {
+      type: "PROGRESS";
+      payload: { step: number; remaining: number; total: number };
+    }
+  | { type: "LOG"; payload: { message: string } }
+  | { type: "ERROR"; payload: { message: string } };
 
 class AlgorithmsRunner {
-    private items: Map<PolicyId, PolicyMeta> = new Map();
-    private status: RunnerStatus = "IDLE";
-    private step = 0;
-    private totalSteps = 0;
-    private rate = 1;
-    private tick: number | null = null;
-    private listeners: Set<(e: RunnerEvent) => void> = new Set();
+  private items: Map<PolicyId, PolicyMeta> = new Map();
+  private status: RunnerStatus = "IDLE";
+  private step = 0;
+  private totalSteps = 0;
+  private rate = 1;
+  private tick: number | null = null;
+  private listeners: Set<(e: RunnerEvent) => void> = new Set();
 
-    constructor() {
-        queueMicrotask(() => this.emit({ type: "READY" }));
+  constructor() {
+    queueMicrotask(() => this.emit({ type: "READY" }));
+  }
+
+  // Events
+  on(fn: (e: RunnerEvent) => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+  private emit(e: RunnerEvent) {
+    for (const fn of this.listeners) {
+      try {
+        fn(e);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("algorithmsRunner listener error", err);
+      }
     }
+  }
 
-    // Events
-    on(fn: (e: RunnerEvent) => void): () => void {
-        this.listeners.add(fn);
-        return () => this.listeners.delete(fn);
-    }
-    private emit(e: RunnerEvent) {
-        for (const fn of this.listeners) {
-            try {
-                fn(e);
-            } catch (err) {
-                // eslint-disable-next-line no-console
-                console.error("algorithmsRunner listener error", err);
-            }
-        }
-    }
+  // Getters
+  getStatus(): RunnerStatus {
+    return this.status;
+  }
+  getStep(): number {
+    return this.step;
+  }
+  getTotalSteps(): number {
+    return this.totalSteps;
+  }
+  getAll(): PolicyMeta[] {
+    return [...this.items.values()];
+  }
 
-    // Getters
-    getStatus(): RunnerStatus { return this.status; }
-    getStep(): number { return this.step; }
-    getTotalSteps(): number { return this.totalSteps; }
-    getAll(): PolicyMeta[] { return [...this.items.values()]; }
+  // Legacy alias
+  init(envConfig: iEnvConfig) {
+    this.configure({ envConfig, totalSteps: 0, rate: 1 });
+  }
 
-    // Legacy alias
-    init(envConfig: iEnvConfig) {
-        this.configure({ envConfig, totalSteps: 0, rate: 1 });
-    }
+  // Lifecycle
+  configure(cfg: RunnerConfig) {
+    try {
+      this.clearTimer();
+      this.items.clear();
+      this.step = 0;
 
-    // Lifecycle
-    configure(cfg: RunnerConfig) {
-        try {
-            this.clearTimer();
-            this.items.clear();
-            this.step = 0;
-
-            // separate envs per policy with seed offsets
-            const mkEnv = (seedOffset: number) =>
-                new GaussianBanditEnv({
-                    ...cfg.envConfig,
-                    seed: (cfg.envConfig.seed ?? 0) + seedOffset,
-                });
-
-            const greedy = new Greedy({
-                ...(cfg.policyConfigs?.greedy ?? {}),
-                arms: cfg.envConfig.arms,
-            } as iBanditPolicyConfig);
-
-            const eps = new EpsilonGreedy({
-                ...(cfg.policyConfigs?.epsgreedy ?? {}),
-                arms: cfg.envConfig.arms,
-            } as iBanditPolicyConfig);
-
-            const greedyEnv = mkEnv(11);
-            const epsEnv = mkEnv(23);
-
-            greedy.initialize(greedyEnv);
-            greedy.reset();
-
-            eps.initialize(epsEnv);
-            eps.reset();
-
-            this.items.set("greedy", {
-                id: "greedy",
-                label: "Greedy",
-                color: "#4fc3f7",
-                policy: greedy,
-                env: greedyEnv,
-                history: [],
-                visible: true,
-            });
-
-            this.items.set("epsgreedy", {
-                id: "epsgreedy",
-                label: "ε-Greedy",
-                color: "#f39c12",
-                policy: eps,
-                env: epsEnv,
-                history: [],
-                visible: true,
-            });
-
-            this.totalSteps = Math.max(0, cfg.totalSteps);
-            this.rate = Math.max(1, cfg.rate);
-            this.status = "CONFIGURED";
-
-            this.emit({ type: "CONFIGURED", payload: { totalSteps: this.totalSteps, rate: this.rate } });
-            this.emit({
-                type: "LOG",
-                payload: {
-                    message: `Konfiguriert: ${this.items.size} Algorithmen · Ziel ${this.totalSteps} Schritte · Rate ${this.rate}/s`,
-                },
-            });
-        } catch (err: any) {
-            this.emit({ type: "ERROR", payload: { message: err?.message ?? String(err) } });
-        }
-    }
-
-    start() {
-        if (!(this.status === "CONFIGURED" || this.status === "PAUSED")) {
-            this.emit({
-                type: "ERROR",
-                payload: { message: `Start in Status "${this.status}" nicht zulässig.` },
-            });
-            return;
-        }
-        if (this.step >= this.totalSteps) {
-            this.step = 0;
-            for (const it of this.items.values()) {
-                it.policy.reset();
-                it.history = [];
-            }
-        }
-
-        this.status = "RUNNING";
-        this.emit({ type: "STARTED" });
-
-        const intervalMs = Math.max(10, Math.floor(1000 / this.rate));
-        this.clearTimer();
-        this.tick = window.setInterval(() => {
-            if (this.status !== "RUNNING") return;
-            if (this.totalSteps > 0 && this.step >= this.totalSteps) {
-                this.stop("Ziel erreicht");
-                return;
-            }
-            this.stepAll();
-        }, intervalMs) as unknown as number;
-    }
-
-    pause() {
-        if (this.status !== "RUNNING") return;
-        this.clearTimer();
-        this.status = "PAUSED";
-        this.emit({ type: "PAUSED" });
-    }
-
-    stop(reason = "Manuell gestoppt") {
-        if (this.status === "IDLE") return;
-        this.clearTimer();
-        this.status = "STOPPED";
-        this.emit({ type: "STOPPED", payload: { reason } });
-    }
-
-    stepOnce() {
-        if (!(this.status === "CONFIGURED" || this.status === "PAUSED")) {
-            this.emit({
-                type: "ERROR",
-                payload: { message: `Einzelschritt in Status "${this.status}" nicht zulässig.` },
-            });
-            return;
-        }
-        if (this.totalSteps > 0 && this.step >= this.totalSteps) {
-            this.emit({ type: "LOG", payload: { message: "Ziel erreicht." } });
-            return;
-        }
-        this.stepAll();
-    }
-
-    // intern
-    private stepAll() {
-        this.step += 1;
-
-        for (const it of this.items.values()) {
-            const action = it.policy.selectAction();
-            const res: iPullResult = it.env.pull(action);
-            it.policy.update(res);
-            it.history.push({
-                action: res.action,
-                reward: res.reward,
-                isOptimal: res.isOptimal,
-            });
-
-            this.emit({
-                type: "RESULT",
-                payload: {
-                    policyId: it.id,
-                    step: this.step,
-                    total: this.totalSteps,
-                    action: res.action,
-                    reward: res.reward,
-                    isOptimal: res.isOptimal,
-                },
-            });
-        }
-
-        this.emit({
-            type: "PROGRESS",
-            payload: {
-                step: this.step,
-                remaining: Math.max(0, this.totalSteps - this.step),
-                total: this.totalSteps,
-            },
+      // separate envs per policy with seed offsets
+      const mkEnv = (seedOffset: number) =>
+        new GaussianBanditEnv({
+          ...cfg.envConfig,
+          seed: (cfg.envConfig.seed ?? 0) + seedOffset,
         });
 
-        if (this.totalSteps > 0 && this.step >= this.totalSteps) {
-            this.stop("Ziel erreicht");
-        }
+      const greedy = new Greedy({
+        ...(cfg.policyConfigs?.greedy ?? {}),
+        arms: cfg.envConfig.arms,
+      } as iBanditPolicyConfig);
+
+      const eps = new EpsilonGreedy({
+        ...(cfg.policyConfigs?.epsgreedy ?? {}),
+        arms: cfg.envConfig.arms,
+      } as iBanditPolicyConfig);
+
+      const greedyEnv = mkEnv(11);
+      const epsEnv = mkEnv(23);
+
+      greedy.initialize(greedyEnv);
+      greedy.reset();
+
+      eps.initialize(epsEnv);
+      eps.reset();
+
+      this.items.set("greedy", {
+        id: "greedy",
+        label: "Greedy",
+        color: "#4fc3f7",
+        policy: greedy,
+        env: greedyEnv,
+        history: [],
+        visible: true,
+      });
+
+      this.items.set("epsgreedy", {
+        id: "epsgreedy",
+        label: "ε-Greedy",
+        color: "#f39c12",
+        policy: eps,
+        env: epsEnv,
+        history: [],
+        visible: true,
+      });
+
+      this.totalSteps = Math.max(0, cfg.totalSteps);
+      this.rate = Math.max(1, cfg.rate);
+      this.status = "CONFIGURED";
+
+      this.emit({
+        type: "CONFIGURED",
+        payload: { totalSteps: this.totalSteps, rate: this.rate },
+      });
+      this.emit({
+        type: "LOG",
+        payload: {
+          message: `Konfiguriert: ${this.items.size} Algorithmen · Ziel ${this.totalSteps} Schritte · Rate ${this.rate}/s`,
+        },
+      });
+    } catch (err: any) {
+      this.emit({
+        type: "ERROR",
+        payload: { message: err?.message ?? String(err) },
+      });
+    }
+  }
+
+  start() {
+    if (!(this.status === "CONFIGURED" || this.status === "PAUSED")) {
+      this.emit({
+        type: "ERROR",
+        payload: {
+          message: `Start in Status "${this.status}" nicht zulässig.`,
+        },
+      });
+      return;
+    }
+    if (this.step >= this.totalSteps) {
+      this.step = 0;
+      for (const it of this.items.values()) {
+        it.policy.reset();
+        it.history = [];
+      }
     }
 
-    private clearTimer() {
-        if (this.tick != null) {
-            clearInterval(this.tick as unknown as number);
-            this.tick = null;
-        }
+    this.status = "RUNNING";
+    this.emit({ type: "STARTED" });
+
+    const intervalMs = Math.max(10, Math.floor(1000 / this.rate));
+    this.clearTimer();
+    this.tick = window.setInterval(() => {
+      if (this.status !== "RUNNING") return;
+      if (this.totalSteps > 0 && this.step >= this.totalSteps) {
+        this.stop("Ziel erreicht");
+        return;
+      }
+      this.stepAll();
+    }, intervalMs) as unknown as number;
+  }
+
+  pause() {
+    if (this.status !== "RUNNING") return;
+    this.clearTimer();
+    this.status = "PAUSED";
+    this.emit({ type: "PAUSED" });
+  }
+
+  stop(reason = "Manuell gestoppt") {
+    if (this.status === "IDLE") return;
+    this.clearTimer();
+    this.status = "STOPPED";
+    this.emit({ type: "STOPPED", payload: { reason } });
+  }
+
+  stepOnce() {
+    if (!(this.status === "CONFIGURED" || this.status === "PAUSED")) {
+      this.emit({
+        type: "ERROR",
+        payload: {
+          message: `Einzelschritt in Status "${this.status}" nicht zulässig.`,
+        },
+      });
+      return;
     }
+    if (this.totalSteps > 0 && this.step >= this.totalSteps) {
+      this.emit({ type: "LOG", payload: { message: "Ziel erreicht." } });
+      return;
+    }
+    this.stepAll();
+  }
+
+  // intern
+  private stepAll() {
+    this.step += 1;
+
+    for (const it of this.items.values()) {
+      const action = it.policy.selectAction();
+      const res: iPullResult = it.env.pull(action);
+      it.policy.update(res);
+      it.history.push({
+        action: res.action,
+        reward: res.reward,
+        isOptimal: res.isOptimal,
+      });
+
+      this.emit({
+        type: "RESULT",
+        payload: {
+          policyId: it.id,
+          step: this.step,
+          total: this.totalSteps,
+          action: res.action,
+          reward: res.reward,
+          isOptimal: res.isOptimal,
+        },
+      });
+    }
+
+    this.emit({
+      type: "PROGRESS",
+      payload: {
+        step: this.step,
+        remaining: Math.max(0, this.totalSteps - this.step),
+        total: this.totalSteps,
+      },
+    });
+
+    if (this.totalSteps > 0 && this.step >= this.totalSteps) {
+      this.stop("Ziel erreicht");
+    }
+  }
+
+  private clearTimer() {
+    if (this.tick != null) {
+      clearInterval(this.tick as unknown as number);
+      this.tick = null;
+    }
+  }
 }
 
 export const algorithmsRunner = new AlgorithmsRunner();

--- a/src/services/algorithmsRunner.ts
+++ b/src/services/algorithmsRunner.ts
@@ -1,0 +1,271 @@
+import type { iBanditPolicy } from "../algorithms/Domain/iBanditPolicy";
+import type { iBanditPolicyConfig } from "../algorithms/Domain/iBanditPolicyConfig";
+import { Greedy } from "../algorithms/greedy";
+import { EpsilonGreedy } from "../algorithms/EpsilonGreedy";
+
+import type { iEnvConfig } from "../env/Domain/iEnvConfig";
+import type { iBanditEnv } from "../env/Domain/iBanditEnv";
+import type { iPullResult } from "../env/Domain/iPullResult";
+import { GaussianBanditEnv } from "../env/GaussianBanditEnv";
+
+export type PolicyId = "greedy" | "epsgreedy";
+
+export type PolicyMeta = {
+    id: PolicyId;
+    label: string;
+    color: string;
+    policy: iBanditPolicy;
+    env: iBanditEnv;
+    history: Array<{ action: number; reward: number; isOptimal: boolean }>;
+    visible?: boolean;
+};
+
+export type RunnerConfig = {
+    envConfig: iEnvConfig;
+    totalSteps: number;
+    rate: number; // steps/second
+    policyConfigs?: Partial<Record<PolicyId, iBanditPolicyConfig>>;
+};
+
+export type RunnerStatus = "IDLE" | "CONFIGURED" | "RUNNING" | "PAUSED" | "STOPPED";
+
+export type RunnerEvent =
+    | { type: "READY" }
+    | { type: "CONFIGURED"; payload: { totalSteps: number; rate: number } }
+    | { type: "STARTED" }
+    | { type: "PAUSED" }
+    | { type: "STOPPED"; payload: { reason: string } }
+    | {
+    type: "RESULT";
+    payload: {
+        policyId: PolicyId;
+        step: number;
+        total: number;
+        action: number;
+        reward: number;
+        isOptimal: boolean;
+    };
+}
+    | { type: "PROGRESS"; payload: { step: number; remaining: number; total: number } }
+    | { type: "LOG"; payload: { message: string } }
+    | { type: "ERROR"; payload: { message: string } };
+
+class AlgorithmsRunner {
+    private items: Map<PolicyId, PolicyMeta> = new Map();
+    private status: RunnerStatus = "IDLE";
+    private step = 0;
+    private totalSteps = 0;
+    private rate = 1;
+    private tick: number | null = null;
+    private listeners: Set<(e: RunnerEvent) => void> = new Set();
+
+    constructor() {
+        queueMicrotask(() => this.emit({ type: "READY" }));
+    }
+
+    // Events
+    on(fn: (e: RunnerEvent) => void): () => void {
+        this.listeners.add(fn);
+        return () => this.listeners.delete(fn);
+    }
+    private emit(e: RunnerEvent) {
+        for (const fn of this.listeners) {
+            try {
+                fn(e);
+            } catch (err) {
+                // eslint-disable-next-line no-console
+                console.error("algorithmsRunner listener error", err);
+            }
+        }
+    }
+
+    // Getters
+    getStatus(): RunnerStatus { return this.status; }
+    getStep(): number { return this.step; }
+    getTotalSteps(): number { return this.totalSteps; }
+    getAll(): PolicyMeta[] { return [...this.items.values()]; }
+
+    // Legacy alias
+    init(envConfig: iEnvConfig) {
+        this.configure({ envConfig, totalSteps: 0, rate: 1 });
+    }
+
+    // Lifecycle
+    configure(cfg: RunnerConfig) {
+        try {
+            this.clearTimer();
+            this.items.clear();
+            this.step = 0;
+
+            // separate envs per policy with seed offsets
+            const mkEnv = (seedOffset: number) =>
+                new GaussianBanditEnv({
+                    ...cfg.envConfig,
+                    seed: (cfg.envConfig.seed ?? 0) + seedOffset,
+                });
+
+            const greedy = new Greedy({
+                ...(cfg.policyConfigs?.greedy ?? {}),
+                arms: cfg.envConfig.arms,
+            } as iBanditPolicyConfig);
+
+            const eps = new EpsilonGreedy({
+                ...(cfg.policyConfigs?.epsgreedy ?? {}),
+                arms: cfg.envConfig.arms,
+            } as iBanditPolicyConfig);
+
+            const greedyEnv = mkEnv(11);
+            const epsEnv = mkEnv(23);
+
+            greedy.initialize(greedyEnv);
+            greedy.reset();
+
+            eps.initialize(epsEnv);
+            eps.reset();
+
+            this.items.set("greedy", {
+                id: "greedy",
+                label: "Greedy",
+                color: "#4fc3f7",
+                policy: greedy,
+                env: greedyEnv,
+                history: [],
+                visible: true,
+            });
+
+            this.items.set("epsgreedy", {
+                id: "epsgreedy",
+                label: "ε-Greedy",
+                color: "#f39c12",
+                policy: eps,
+                env: epsEnv,
+                history: [],
+                visible: true,
+            });
+
+            this.totalSteps = Math.max(0, cfg.totalSteps);
+            this.rate = Math.max(1, cfg.rate);
+            this.status = "CONFIGURED";
+
+            this.emit({ type: "CONFIGURED", payload: { totalSteps: this.totalSteps, rate: this.rate } });
+            this.emit({
+                type: "LOG",
+                payload: {
+                    message: `Konfiguriert: ${this.items.size} Algorithmen · Ziel ${this.totalSteps} Schritte · Rate ${this.rate}/s`,
+                },
+            });
+        } catch (err: any) {
+            this.emit({ type: "ERROR", payload: { message: err?.message ?? String(err) } });
+        }
+    }
+
+    start() {
+        if (!(this.status === "CONFIGURED" || this.status === "PAUSED")) {
+            this.emit({
+                type: "ERROR",
+                payload: { message: `Start in Status "${this.status}" nicht zulässig.` },
+            });
+            return;
+        }
+        if (this.step >= this.totalSteps) {
+            this.step = 0;
+            for (const it of this.items.values()) {
+                it.policy.reset();
+                it.history = [];
+            }
+        }
+
+        this.status = "RUNNING";
+        this.emit({ type: "STARTED" });
+
+        const intervalMs = Math.max(10, Math.floor(1000 / this.rate));
+        this.clearTimer();
+        this.tick = window.setInterval(() => {
+            if (this.status !== "RUNNING") return;
+            if (this.totalSteps > 0 && this.step >= this.totalSteps) {
+                this.stop("Ziel erreicht");
+                return;
+            }
+            this.stepAll();
+        }, intervalMs) as unknown as number;
+    }
+
+    pause() {
+        if (this.status !== "RUNNING") return;
+        this.clearTimer();
+        this.status = "PAUSED";
+        this.emit({ type: "PAUSED" });
+    }
+
+    stop(reason = "Manuell gestoppt") {
+        if (this.status === "IDLE") return;
+        this.clearTimer();
+        this.status = "STOPPED";
+        this.emit({ type: "STOPPED", payload: { reason } });
+    }
+
+    stepOnce() {
+        if (!(this.status === "CONFIGURED" || this.status === "PAUSED")) {
+            this.emit({
+                type: "ERROR",
+                payload: { message: `Einzelschritt in Status "${this.status}" nicht zulässig.` },
+            });
+            return;
+        }
+        if (this.totalSteps > 0 && this.step >= this.totalSteps) {
+            this.emit({ type: "LOG", payload: { message: "Ziel erreicht." } });
+            return;
+        }
+        this.stepAll();
+    }
+
+    // intern
+    private stepAll() {
+        this.step += 1;
+
+        for (const it of this.items.values()) {
+            const action = it.policy.selectAction();
+            const res: iPullResult = it.env.pull(action);
+            it.policy.update(res);
+            it.history.push({
+                action: res.action,
+                reward: res.reward,
+                isOptimal: res.isOptimal,
+            });
+
+            this.emit({
+                type: "RESULT",
+                payload: {
+                    policyId: it.id,
+                    step: this.step,
+                    total: this.totalSteps,
+                    action: res.action,
+                    reward: res.reward,
+                    isOptimal: res.isOptimal,
+                },
+            });
+        }
+
+        this.emit({
+            type: "PROGRESS",
+            payload: {
+                step: this.step,
+                remaining: Math.max(0, this.totalSteps - this.step),
+                total: this.totalSteps,
+            },
+        });
+
+        if (this.totalSteps > 0 && this.step >= this.totalSteps) {
+            this.stop("Ziel erreicht");
+        }
+    }
+
+    private clearTimer() {
+        if (this.tick != null) {
+            clearInterval(this.tick as unknown as number);
+            this.tick = null;
+        }
+    }
+}
+
+export const algorithmsRunner = new AlgorithmsRunner();


### PR DESCRIPTION
- Auto-Run steuern: Neuer Play/Pause-Button als runder, deutlich markierter FAB neben den Aktionsbuttons. Statusbadge („Bereit / Läuft / Pausiert / Gestoppt“) steht rechts im Titel.
- Buttons & Layout: „Konfigurieren“ und „+1 Schritt“ erscheinen im gleichen Segment-Stil wie im Environment-Setup. Der Play/Pause-Button ist optisch aufgeräumt und vertikal zu den Buttons ausgerichtet.
- Manuell vs. Algos: Jeder manuelle Klick triggert weiterhin alle Algorithmen einen Schritt mit – der Vergleich ist sofort im Chart und in der Tabelle sichtbar.
- Serien-Pillen: Die Algorithmus-Serien sind immer registriert; Pillen sind damit auch ohne aktives Environment sichtbar.
- Vergleich & Kennzahlen: Der Abschnitt klappt jetzt wie „Debug & Log“ ein/aus (gleiche Kopfzeile, gleicher Look).
- Charts wirken flüssiger: Bei niedrigen Schritt-Raten laufen Linien zwischen neuen Punkten mit sanfter Tween-Animation; Rendering ist generell weniger „stotternd“.