### PR TITLE
Bug Fix und Debug Erweiterung

### DIFF
--- a/src/algorithms/BasePolicy.ts
+++ b/src/algorithms/BasePolicy.ts
@@ -57,7 +57,7 @@ export abstract class BasePolicy implements iBanditPolicy {
    * Q und N auf Startwerte (bzw. 0) setzen, t auf 0.
    */
   reset(): void {
-    const optimisticValue = this.cfg.optimisticInitialValue ?? 0;
+    const optimisticValue = this.setOptimisticInitialValue();
     this.Q.fill(optimisticValue); // alle Q-Werte auf Anfang setzen (optimistisch)
     this.N.fill(0); // Zähler zurücksetzen
     this.t = 0; // Gesamtanzahl Steps zurücksetzen
@@ -75,7 +75,9 @@ export abstract class BasePolicy implements iBanditPolicy {
     this.N[a] += 1; // Zähler des Arms erhöhen
     const n = this.N[a]; // Anzahl Ziehungen dieses Arms
     // Mittelwert-Update mit inkrementeller Form
-    this.Q[a] += (result.reward - this.Q[a]) / n;
+    this.Q[a] += (result.reward - this.Q[a]) / (n + 1);
+    //Alt
+    // this.Q[a] += (result.reward - this.Q[a]) / n+1;
     this.t += 1; // Gesamtanzahl Schritte erhöhen
   }
 

--- a/src/algorithms/EpsilonGreedy.ts
+++ b/src/algorithms/EpsilonGreedy.ts
@@ -21,6 +21,6 @@ export class EpsilonGreedy extends BasePolicy {
     return raw;
   }
   protected override setOptimisticInitialValue(): number {
-    return this.cfg.optimisticInitialValue ?? 150;
+    return this.cfg.optimisticInitialValue ?? 500;
   }
 }

--- a/src/algorithms/greedy.ts
+++ b/src/algorithms/greedy.ts
@@ -6,6 +6,6 @@ export class Greedy extends BasePolicy {
     return this.tiebreak(this.getEstimates() as number[]);
   }
   protected override setOptimisticInitialValue(): number {
-    return this.cfg.optimisticInitialValue ?? 100; // Hier geringerer Wert weil Greedy sonst "zu oft" den passenden Arm gefunden hat
+    return this.cfg.optimisticInitialValue ?? 350; // Hier geringerer Wert weil Greedy sonst "zu oft" den passenden Arm gefunden hat
   }
 }

--- a/src/services/algorithmsRunner.ts
+++ b/src/services/algorithmsRunner.ts
@@ -48,6 +48,7 @@ export type RunnerEvent =
         total: number;
         action: number;
         reward: number;
+        expected: number;
         isOptimal: boolean;
       };
     }
@@ -121,12 +122,13 @@ class AlgorithmsRunner {
         });
 
       const greedy = new Greedy({
-        ...(cfg.policyConfigs?.greedy ?? {}),
+        ...(cfg.policyConfigs?.greedy ?? undefined),
+        // optimisticInitialValue: cfg.policyConfigs?.greedy?.optimisticInitialValue,
         arms: cfg.envConfig.arms,
       } as iBanditPolicyConfig);
 
       const eps = new EpsilonGreedy({
-        ...(cfg.policyConfigs?.epsgreedy ?? {}),
+        ...(cfg.policyConfigs?.epsgreedy ?? undefined),
         arms: cfg.envConfig.arms,
       } as iBanditPolicyConfig);
 
@@ -134,10 +136,8 @@ class AlgorithmsRunner {
       const epsEnv = mkEnv(23);
 
       greedy.initialize(greedyEnv);
-      greedy.reset();
 
       eps.initialize(epsEnv);
-      eps.reset();
 
       this.items.set("greedy", {
         id: "greedy",
@@ -267,6 +267,7 @@ class AlgorithmsRunner {
           total: this.totalSteps,
           action: res.action,
           reward: res.reward,
+          expected: it.policy.getEstimates()[res.action],
           isOptimal: res.isOptimal,
         },
       });

--- a/src/services/debugStore.ts
+++ b/src/services/debugStore.ts
@@ -82,7 +82,7 @@ export function attachRunner(runner: {
         break;
       case "RESULT":
         debug.log(
-          `#${e.payload?.step}/${e.payload?.total} • ${e.payload?.policyId} • a=${e.payload?.action} • r=${Number(e.payload?.reward).toFixed(2)}${e.payload?.isOptimal ? " • optimal" : ""}`,
+          `#${e.payload?.step}/${e.payload?.total} • ${e.payload?.policyId} • a=${e.payload?.action} • r=${Number(e.payload?.reward).toFixed(2)} • q=${Number(e.payload?.expected).toFixed(2)} ${e.payload?.isOptimal ? " • optimal" : ""}`,
           "result",
           e.payload,
         );

--- a/src/tests/Greedy.spec.ts
+++ b/src/tests/Greedy.spec.ts
@@ -25,16 +25,16 @@ describe("Greedy Policy", () => {
 
   it("update aktualisiert Q korrekt (inkrementelles Mittel)", () => {
     pol.update({ action: 0, reward: 10, isOptimal: false });
-    expect(pol.getEstimates()[0]).toBe(10);
+    expect(pol.getEstimates()[0]).toBe(180);
 
     pol.update({ action: 0, reward: 0, isOptimal: false });
-    expect(pol.getEstimates()[0]).toBe(5); // (10+0)/2
+    expect(pol.getEstimates()[0]).toBe(120);
   });
 
   it("reset setzt alle Werte zurück", () => {
     pol.update({ action: 1, reward: 5, isOptimal: false });
     pol.reset();
-    expect(pol.getEstimates()).toEqual([0, 0, 0]);
+    expect(pol.getEstimates()).toEqual([350, 350, 350]);
     expect(pol.getCounts()).toEqual([0, 0, 0]);
   });
 });


### PR DESCRIPTION
Es gab einen Bug bei welchem der Default Wert von Greedy und E Greedy nicht übernommen wurden. Dieser wurde behoben. Sowohl Greedy und E Greedy brauchen weniger Zeit zum Finden der 'richtigen' Arme. Außerdem wurde im Debug und Log fenster ergänzt, dass nun der vom Algorithmus geschätze Wert ausgegeben wird. (Hat beim Debuggen geholfen. Lass ich jetzt mal drin)